### PR TITLE
feat(neovim): update golang LSP & linter config

### DIFF
--- a/home/dot_config/nvim/lua/lsp/servers/gopls.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/gopls.lua
@@ -7,15 +7,21 @@ return {
   root_dir  = lspconfig.util.root_pattern("go.mod", "go.work", ".git"),
   settings  = {
     gopls = {
+      -- Completion settings
       usePlaceholders = true,
       completeUnimported = true,
       experimentalPostfixCompletions = true,
-      staticcheck = true,
-      analyses = {
-        unusedparams = true,
-        shadow = false,
-      }
-    }
+      completionDocumentation = true,
+      deepCompletion = true,
+
+      -- the following diagnostics options are leave it to `revive`
+      -- staticcheck = true,
+      -- analyses = {
+      --   unusedparams = true,
+      --   unreachable  = true,
+      --   shadow       = false,
+      -- },
+    },
   },
   single_file_support = true,
 }


### PR DESCRIPTION
disable diagnostics to use `revive`