### PR TITLE
198 feature update mise config

### DIFF
--- a/home/dot_config/fish/conf.d/lang.fish.tmpl
+++ b/home/dot_config/fish/conf.d/lang.fish.tmpl
@@ -4,7 +4,6 @@
 set -gx RUST_BACKTRACE full
 
 # Python
-set -gx MISE_PYTHON_COMPILE 0
 set -gx PYTHON_BUILD_CACHE_PATH "$HOME/.cache/pyenv"
 set -gx PYTHON_BUILD_HTTP_CLIENT "aria2c"
 
@@ -15,8 +14,6 @@ set -gx PYTHON_CONFIGURE_OPTS "--enable-shared --enable-optimizations --with-lto
 {{ else -}}
 set -gx PYTHON_CONFIGURE_OPTS "--enable-optimizations --with-lto=full"
 {{- end -}}
-set -gx PYTHON_CFLAGS "-march=native -mtune=native"
-# set -gx PYTHON_BUILD_SKIP_HOMEBREW 1
 
 # Ruby
 set -gx RUBY_CFLAGS "-Wno-error=implicit-function-declaration"

--- a/home/dot_config/homebrew/Brewfile.tmpl
+++ b/home/dot_config/homebrew/Brewfile.tmpl
@@ -77,6 +77,10 @@ brew "sqlite"
 ## Go
 brew "goreleaser/tap/goreleaser"
 
+## Python
+brew "tcl-tk"
+brew "python-tk@3.12"
+
 {{ if not .headless }}
 ## CSV
 brew "csview"

--- a/home/dot_config/mise/settings.toml.tmpl
+++ b/home/dot_config/mise/settings.toml.tmpl
@@ -39,3 +39,15 @@ disable_tools = []                 # disable specific tools, generally used to t
 env_file = '.env' # load env vars from a dotenv file, see `MISE_ENV_FILE`
 
 experimental = true # enable experimental features
+
+## Python
+python_compile = false
+{{- if eq .chezmoi.arch "arm64" }}
+python_precompiled_arch = "aarch64"
+{{- else if eq .chezmoi.arch "amd64" }}
+{{- if eq .chezmoi.os "darwin" }}
+python_precompiled_arch = "x86_64"
+{{- else if eq "linux" }}
+python_precompiled_arch = "x86_64_v3"
+{{- end }}
+{{- end }}

--- a/home/dot_config/mise/settings.toml.tmpl
+++ b/home/dot_config/mise/settings.toml.tmpl
@@ -4,6 +4,7 @@
 # for example, .nvmrc in the case of node's nvm
 legacy_version_file = true                     # enabled by default (unlike asdf)
 legacy_version_file_disable_tools = [          # disable for specific tools
+  "node",
   "python",
   "ruby",
 ]


### PR DESCRIPTION
* disable legacy version file for `node.js`
* enable installing precompiled `python` binary with `mise`
* install `tcl-tk` & `python-tk@3.12` to use `tkinter` on `python@3.12`