### PR TITLE
248 feature refine ci config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
+          # TODO: enable for cross platform env
           path: ${HOME}/Library/Caches/Homebrew
           key: ${{ runner.os }}-homebrew-cache-${{ env.cache-version }}
 
@@ -57,11 +58,20 @@ jobs:
         run: |
           sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply -S .
 
+      - name: Setup Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Install Homebrew packages with Brewfile
+        run: |
+          brew update
+          brew bundle -v --file=${HOME}/.config/homebrew/Brewfile
+
       - name: Save Homebrew cache
         uses: actions/cache/save@v4
         if: always()
         with:
           enableCrossOsArchive: true
+          # TODO: enable for cross platform env
           path: ${HOME}/Library/Caches/Homebrew
           key: ${{ runner.os }}-homebrew-cache-${{ env.cache-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Save Homebrew cache
         uses: actions/cache/save@v4
-        # if: always()
+        if: always()
         with:
           enableCrossOsArchive: true
           path: ${HOME}/Library/Caches/Homebrew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
           GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
           GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
         run: |
-          rm '/usr/local/bin/2to3'
           sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply -S .
 
       - name: Save Homebrew cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
           path: ${HOME}/Library/Caches/Homebrew
           key: ${{ runner.os }}-homebrew-cache-${{ env.cache-version }}
 
+      - name: Install runtime with mise
+        uses: jdx/mise-action@v2
+        with:
+          version: latest
+
       - name: Save mise cache
         uses: actions/cache/save@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         os:
         - macos-latest
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     timeout-minutes: 20
     # sptesの並列化で高速化できる
     # https://qiita.com/qualitia_cdev/items/407b0df9c0a0f0f45bbc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
-          path: /Users/runner/Library/Caches/Homebrew
+          path: ${HOME}/Library/Caches/Homebrew
           key: ${{ runner.os }}-homebrew-cache-${{ env.cache-version }}
 
       - name: Restore mise cache
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
-          path: /Users/runner/.local/share/mise
+          path: ${HOME}/.local/share/mise
           key: ${{ runner.os }}-mise-cache-${{ env.cache-version }}
 
       - name: Decrypt age key
@@ -62,7 +62,7 @@ jobs:
         # if: always()
         with:
           enableCrossOsArchive: true
-          path: /Users/runner/Library/Caches/Homebrew
+          path: ${HOME}/Library/Caches/Homebrew
           key: ${{ runner.os }}-homebrew-cache-${{ env.cache-version }}
 
       - name: Save mise cache
@@ -70,7 +70,7 @@ jobs:
         if: always()
         with:
           enableCrossOsArchive: true
-          path: /Users/runner/.local/share/mise
+          path: ${HOME}/.local/share/mise
           key: ${{ runner.os }}-mise-cache-${{ env.cache-version }}
 
       - name: Remove age key

--- a/home/.chezmoiscripts/run_once_after_00-homebrew.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_00-homebrew.sh.tmpl
@@ -7,6 +7,7 @@ set -eo pipefail
 {{ template "common/script_sudo" . }}
 {{ template "common/script_helper" . }}
 
+{{- if not .headless }}
 # Install Homebrew
 BREW_DIR="$HOME/.config/homebrew"
 if ! command_exists brew && [ -f "$BREW_DIR/Brewfile" ]; then
@@ -16,9 +17,8 @@ fi
 # Install Homebrew packages
 brew bundle -v --file="$BREW_DIR/Brewfile"
 
-{{ if not .headless }}
 brew bundle -v --file="$BREW_DIR/Caskfile"
 brew bundle -v --file="$BREW_DIR/Masfile"
-{{ end }}
+{{- end }}
 
 brew list

--- a/home/.chezmoiscripts/run_onchange_after_20-mise.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_20-mise.sh.tmpl
@@ -3,6 +3,8 @@
 
 set -eo pipefail
 
+{{- if not .headless }}
 mise trust $HOME/.config/mise/config.toml
 mise install
 mise current
+{{- end }}

--- a/home/dot_config/homebrew/Brewfile.tmpl
+++ b/home/dot_config/homebrew/Brewfile.tmpl
@@ -62,9 +62,6 @@ brew "lazygit"
 brew "gh"
 brew "ghq"
 
-## Version Management
-brew "mise"
-
 ## Build
 brew "cmake"
 
@@ -82,6 +79,9 @@ brew "tcl-tk"
 brew "python-tk@3.12"
 
 {{- if not .headless }}
+## Version Management
+brew "mise"
+
 ## CSV
 brew "xsv"
 


### PR DESCRIPTION
* enable `continue-on-error` to run job after failed
* unify path into `${HOME}` instead of `/Users/runner`
* setup `Homebrew` with **[homebrew/actions](https://github.com/homebrew/actions)**
* setup runtime environment with **[jdx/mise-action](jdx/mise-action)**
