### PR TITLE
ci(mise): add environment variables like `mise trust` to install runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Install runtime with mise
         if: always()
+        env:
+          MISE_TRUSTED_CONFIG_PATHS: ${HOME}/.config/mise/config.toml
         uses: jdx/mise-action@v2
 
       - name: Save mise cache


### PR DESCRIPTION
* add environment variables like mise trust to install runtime