### PR TITLE
256 feature update ci config for homebrew mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,6 @@ jobs:
           MISE_TRUSTED_CONFIG_PATHS: ~/.config/mise/config.toml
         uses: jdx/mise-action@v2
 
-      - name: Save mise cache
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          enableCrossOsArchive: true
-          path: ~/.local/share/mise
-          key: ${{ runner.os }}-mise-cache-${{ env.cache-version }}
-
       - name: Remove age key
         if: always()
         run: rm ${HOME}/.config/chezmoi/key.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           enableCrossOsArchive: true
           # TODO: enable for cross platform env
-          path: ${HOME}/Library/Caches/Homebrew
+          path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-homebrew-cache-${{ env.cache-version }}
 
       - name: Decrypt age key
@@ -67,13 +67,13 @@ jobs:
         with:
           enableCrossOsArchive: true
           # TODO: enable for cross platform env
-          path: ${HOME}/Library/Caches/Homebrew
+          path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-homebrew-cache-${{ env.cache-version }}
 
       - name: Install runtime with mise
         if: always()
         env:
-          MISE_TRUSTED_CONFIG_PATHS: ${HOME}/.config/mise/config.toml
+          MISE_TRUSTED_CONFIG_PATHS: ~/.config/mise/config.toml
         uses: jdx/mise-action@v2
 
       - name: Save mise cache
@@ -81,7 +81,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           enableCrossOsArchive: true
-          path: ${HOME}/.local/share/mise
+          path: ~/.local/share/mise
           key: ${{ runner.os }}-mise-cache-${{ env.cache-version }}
 
       - name: Remove age key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 
 env:
   cache-version: v5
+  HOMEBREW_NO_INSTALL_FROM_API:
 
 jobs:
   ci:


### PR DESCRIPTION
* fix `${HOME}` path evaluated as string
* add `HOMEBREW_NO_INSTALL_FROM_API` as homebrew environment variable
* remove saving `mise` cache action