### PR TITLE
288 feature update yt dlp config

### DIFF
--- a/home/dot_config/yt-dlp/config.tmpl
+++ b/home/dot_config/yt-dlp/config.tmpl
@@ -3,6 +3,9 @@
 --ignore-errors
 --verbose
 
+# Cookie
+--cookies-from-browser brave
+
 # Embed
 # --embed-metadata
 # --embed-thumbnail

--- a/home/dot_config/yt-dlp/config.tmpl
+++ b/home/dot_config/yt-dlp/config.tmpl
@@ -10,6 +10,9 @@
 # --embed-metadata
 # --embed-thumbnail
 
+# Avoid vp9 because we have no HW acceleration in LXC
+-S vcodec:h264
+
 # Output format
 --output "%(title)s.%(ext)s"
 

--- a/home/dot_config/yt-dlp/config.tmpl
+++ b/home/dot_config/yt-dlp/config.tmpl
@@ -13,6 +13,9 @@
 # Avoid vp9 because we have no HW acceleration in LXC
 -S vcodec:h264
 
+# Quality
+--format 'bestvideo[ext=mp4][height<=1080][fps<=30]+bestaudio[ext=m4a]/best[ext=mp4][height<=1080][fps<=30]/best'
+
 # Output format
 --output "%(title)s.%(ext)s"
 


### PR DESCRIPTION
* use browser cookie with `--cookies-from-browser`
* specify video codec to `h264` to use HW acceleration
* limit video quality
  * limit size with `[height<=1080]`
  * limit fps with `[fps<=30]`
