### PR TITLE
304 feature update fish path config

### DIFF
--- a/home/dot_config/fish/conf.d/lang.fish.tmpl
+++ b/home/dot_config/fish/conf.d/lang.fish.tmpl
@@ -3,7 +3,7 @@
 # Rust
 set -gx RUST_BACKTRACE full
 if test -d $HOME/.cargo/bin
-  fish_add_path --universal $HOME/.cargo/bin
+  fish_add_path $HOME/.cargo/bin
 end
 
 # Python

--- a/home/dot_config/fish/conf.d/lang.fish.tmpl
+++ b/home/dot_config/fish/conf.d/lang.fish.tmpl
@@ -25,5 +25,5 @@ set -gx RUBY_CONFIGURE_OPTS "--with-openssl-dir=$(brew --prefix openssl@3) --wit
 # pnpm
 set -gx PNPM_HOME "$HOME/.local/share/pnpm"
 if not string match -q -- $PNPM_HOME $PATH
-  set -gx PATH "$PNPM_HOME" $PATH
+  fish_add_path $PNPM_HOME
 end

--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -83,9 +83,6 @@ type -q thefuck && thefuck --alias | source
 # Note: this is required for `pnpm` completion
 [ -f ~/.config/tabtab/fish/__tabtab.fish ]; and . ~/.config/tabtab/fish/__tabtab.fish; or true
 
-# Wine
-set -x PATH "$HOMEBREW_PREFIX/opt/wine-6.1/bin" $PATH
-
 # Fish
 abbr -a -- cl clear
 abbr -a -- x exit

--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -6,6 +6,11 @@ set -x LC_CTYPE ja_JP.UTF-8
 
 # Path Configuration
 set -g PATH /bin /sbin /usr/local/bin /usr/local/sbin /usr/bin /usr/sbin $HOME/.local/bin $PATH
+fish_add_path /usr/local/bin
+fish_add_path /usr/local/sbin
+fish_add_path /usr/bin
+fish_add_path /usr/sbin
+fish_add_path $HOME/.local/bin
 
 {{- if eq .chezmoi.arch "arm64" }}
 set -gx ARCHFLAGS '-arch arm64'

--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -5,7 +5,6 @@ set -x LANG ja_JP.UTF-8
 set -x LC_CTYPE ja_JP.UTF-8
 
 # Path Configuration
-set -g PATH /bin /sbin /usr/local/bin /usr/local/sbin /usr/bin /usr/sbin $HOME/.local/bin $PATH
 fish_add_path /usr/local/bin
 fish_add_path /usr/local/sbin
 fish_add_path /usr/bin


### PR DESCRIPTION
* configure `$PATH` using `fish_add_path` not `set -gx PATH`
  * `/usr/local/bin`
  * `/usr/local/sbin`
  * `/usr/bin`
  * `/usr/sbin`
  * `$HOME/.local/bin`
  * `$HOME/.cargo/bin`
  * `$PNPM_HOME`
