### PR TITLE
ci: remove `dependabot` config (#356)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
to prevent conflicting with `renovate`

## Summary
<!-- add the description of the PR here -->

* remove `.github/dependabot.yml`

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #356

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->
