### PR TITLE
feat: dynamic language environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   [license-badge]: https://img.shields.io/github/license/MasahiroSakoda/dotfiles
   [license-file]: https://github.com/MasahiroSakoda/dotfiles/blob/main/LICENSE
 
-  [![Codacy Security Scan](https://github.com/MasahiroSakoda/dotfiles/actions/workflows/codacy.yml/badge.svg)](https://github.com/MasahiroSakoda/dotfiles/actions/workflows/codacy.yml)
+  [![linter](https://github.com/MasahiroSakoda/dotfiles/actions/workflows/linter.yml/badge.svg)](https://github.com/MasahiroSakoda/dotfiles/actions/workflows/linter.yml)
   [![ci](https://github.com/MasahiroSakoda/dotfiles/actions/workflows/ci.yml/badge.svg?event=pull_request)](https://github.com/MasahiroSakoda/dotfiles/actions/workflows/ci.yml)
 </div>
 

--- a/README.md
+++ b/README.md
@@ -294,12 +294,15 @@ Runtime version management tool
 
 `.tool-versions` used by `asdf` is deactivated to prevent confliction & confusion.
 
+global language environment predefined in [**`.chezmoidata.toml`**][chezmoidata]
+
 | File                         | Usage           |
 |:-----------------------------|:----------------|
 | [**`~/.config/mise/settings.toml`**][mise-settings] | System settings |
 | [**`~/.config/mise/config.toml`**][mise-global]   | Global config   |
 | `.mise.toml`                   | Local config    |
 
+[chezmoidata]:  https://github.com/MasahiroSakoda/dotfiles/blob/main/home/.chezmoidata.toml
 [mise-global]: https://github.com/MasahiroSakoda/dotfiles/blob/main/home/dot_config/mise/config.toml.tmpl
 [mise-settings]: https://github.com/MasahiroSakoda/dotfiles/blob/main/home/dot_config/mise/settings.toml.tmpl
 

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -80,7 +80,7 @@ enabled  = true
 versions = ["1"]
 
 [mise.bun]
-enabled  = true
+enabled  = false
 versions = ["1"]
 
 [mise.go]

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -67,15 +67,33 @@ color = "#3399ff"
 chatgpt = true
 copilot = true
 
-[mise]
-bun    = "1"
-deno   = "1"
-go     = "latest"
-node   = "20"
-pnpm   = "latest"
-python = "3.12"
-ruby   = "3.3"
-usage  = "latest"
+[mise.node]
+enabled  = true
+versions = ["20"]
+
+[mise.pnpm]
+enabled  = true
+versions = ["latest"]
+
+[mise.deno]
+enabled  = true
+versions = ["1"]
+
+[mise.bun]
+enabled  = true
+versions = ["1"]
+
+[mise.go]
+enabled  = true
+versions = ["latest"]
+
+[mise.python]
+enabled  = true
+versions = ["3.11", "3.12"]
+
+[mise.ruby]
+enabled  = true
+versions = ["3.3"]
 
 [packages]
 npm = [

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -59,6 +59,26 @@ install.sh
 
 key.txt.age
 
+# Language specific files
+{{- if not .mise.go.enabled }}
+.default-go-packages
+{{- end }}
+
+{{- if not .mise.python.enabled }}
+.default-python-packages
+.chezmoiscripts/run_onchange_after_21-python.sh.tmpl
+{{- end }}
+
+{{- if not .mise.ruby.enabled }}
+.default-gems
+.chezmoiscripts/run_onchange_after_22-ruby.sh.tmpl
+{{- end }}
+
+{{- if not .mise.node.enabled }}
+.default-npm-packages
+.chezmoiscripts/run_onchange_after_23-nodejs.sh.tmpl
+{{- end }}
+
 # Ignore non-macOS files.
 {{ if ne .chezmoi.os "darwin" -}}
 .hammerspoon

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -5,14 +5,13 @@
 NODE_ENV = 'development'
 
 [tools]
-go     = "{{ .mise.go }}"
-node   = "{{ .mise.node }}"
-pnpm   = "{{ .mise.pnpm }}"
-deno   = "{{ .mise.deno }}"
-bun    = "{{ .mise.bun }}"
-python = "{{ .mise.python }}"
-ruby   = "{{ .mise.ruby }}"
-usage  = "{{ .mise.usage }}"
+{{- range $lang, $content := .mise }}
+{{- $enabled := $content.enabled }}
+{{- $versions:= $content.versions }}
+{{- if $enabled }}
+{{ $lang }} = [{{ range $i, $ver := $versions }}{{ if $i }}, {{ end }}{{ . | quote }}{{ end }}]
+{{- end }}
+{{- end }}
 
 # supports everything you can do with .tool-versions currently
 # nodejs = ['16', 'prefix:20', 'ref:master', 'path:~/.nodes/14']


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

add language specified  `enabled` flag to  deploy & run scripts

#### Target language environment
* `golang`
* `node.js`
* `python`
* `ruby`

#### target files
* `.config/mise/config.toml`
* `.default-*`
* `.chezmoiscripts/*.sh`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #377

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
