### PR TITLE
feat(neovim): extend luasnip filetypes

### DIFF
--- a/home/dot_config/nvim/after/ftplugin/python.lua
+++ b/home/dot_config/nvim/after/ftplugin/python.lua
@@ -1,3 +1,2 @@
 -- -*-mode:lua-*- vim:ft=lua
-require("luasnip").filetype_extend("python", { "django" })
 require("dap.adapters.debugpy")

--- a/home/dot_config/nvim/after/ftplugin/ruby.lua
+++ b/home/dot_config/nvim/after/ftplugin/ruby.lua
@@ -1,3 +1,2 @@
 -- -*-mode:lua-*- vim:ft=lua
-require("luasnip").filetype_extend("ruby", { "rails" })
 require("dap.adapters.ruby")

--- a/home/dot_config/nvim/lua/lsp/cmp/luasnip.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/luasnip.lua
@@ -1,6 +1,19 @@
 local ok, luasnip = pcall(require, "luasnip")
 if not ok then return end
 
+luasnip.filetype_extend("c",      { "cdoc" })
+luasnip.filetype_extend("cpp",    { "cppdoc" })
+luasnip.filetype_extend("rust",   { "rustdoc" })
+luasnip.filetype_extend("kotlin", { "kdoc" })
+luasnip.filetype_extend("php",    { "phpdoc" })
+luasnip.filetype_extend("ruby",   { "rdoc", "rails" })
+luasnip.filetype_extend("python", { "pydoc", "django" })
+luasnip.filetype_extend("lua",    { "luadoc" })
+luasnip.filetype_extend("javascript", { "javascriptreact", "html" })
+luasnip.filetype_extend("typescript", { "typescript", "html" })
+luasnip.filetype_extend("javascriptreact", { "javascript", "html" })
+luasnip.filetype_extend("typescriptreact", { "typescript", "html" })
+
 luasnip.config.set_config({
   history = true,
 


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

* extend luasnip filetypes for following languages
  * `c`
  * `cpp
  * `rust`
  * `kotlin`
  * `php`
  * `python`
  * `ruby`
  * `lua`
  * `javascript`,  `javascriptreact`
  * `typescript`, `typescriptreact`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #403

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
