### PR TITLE
fix(neovim): fix `lua` table structure to prevent checkhealth warning

### DIFF
--- a/home/dot_config/nvim/lua/plugins/init.lua
+++ b/home/dot_config/nvim/lua/plugins/init.lua
@@ -1,14 +1,20 @@
 -- -*-mode:lua-*- vim:ft=lua
-
-return {
-  require("plugins.dependencies"),
-  require("plugins.appearance"),
-  require("plugins.editor"),
-  require("plugins.lsp"),
-  require("plugins.cmp"),
-  require("plugins.dap"),
-  require("plugins.treesitter"),
-  require("plugins.telescope"),
-  require("plugins.ai"),
-  require("plugins.misc"),
+local plugins = {}
+local list = {
+  "plugins.dependencies",
+  "plugins.appearance",
+  "plugins.editor",
+  "plugins.lsp",
+  "plugins.cmp",
+  "plugins.dap",
+  "plugins.treesitter",
+  "plugins.telescope",
+  "plugins.ai",
+  "plugins.misc",
 }
+
+for _, plugin in ipairs(list) do
+  vim.tbl_deep_extend("keep", plugins, require(plugin))
+end
+
+return plugins


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

* fix lua table structure to  fix `checkhealth` warning for `lazy.nvim`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #407

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
