### PR TITLE
chore(vscode): remove `editor.tabSize` option

### DIFF
--- a/home/.chezmoitemplates/common/vscode-settings.json.tmpl
+++ b/home/.chezmoitemplates/common/vscode-settings.json.tmpl
@@ -117,17 +117,14 @@
     "editor.semanticHighlighting.enabled": true
   },
   "[rust]": {
-    "editor.tabSize": 4
   },
   "go.buildOnSave": "workspace",
   "[go][go.mod]": {
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     },
-    "editor.tabSize": 4
   },
   "[lua]": {
-    "editor.tabSize": 2
   },
   "[json]": {
     "editor.quickSuggestions": {
@@ -149,18 +146,15 @@
     },
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.suggestSelection": "first",
-    "editor.tabSize": 4
   },
   "notebook.cellToolbarLocation": {
     "default": "right",
     "jupyter-notebook": "left"
   },
   "[ruby]": {
-    "editor.tabSize": 2
   },
   "[yaml]": {
     "editor.insertSpaces": true,
-    "editor.tabSize": 2,
     "editor.autoIndent": "advanced",
     "diffEditor.ignoreTrimWhitespace": false
   },


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

* remove indent options to configure with `.editorconfig` for specific languages

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #435

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
