### PR TITLE
chore(neovim): remove unused telescope path option

### DIFF
--- a/home/dot_config/nvim/lua/user/telescope/init.lua
+++ b/home/dot_config/nvim/lua/user/telescope/init.lua
@@ -29,7 +29,6 @@ telescope.setup({
     winblend = 30,
     file_ignore_patterns = patterns,
     path_display = {
-      shorten  = { len = 1, exlude = { 1, -2, -1 } },
       truncate = true,
     },
     mappings = {


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

* [x] remove `shoten` option

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #487

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
