### PR TITLE
feat: update vscode keybindings

### DIFF
--- a/home/.chezmoitemplates/common/vscode-keybindings.json.tmpl
+++ b/home/.chezmoitemplates/common/vscode-keybindings.json.tmpl
@@ -1,16 +1,3 @@
 // -*-mode:jsonc-*- vim:ft=jsonc.gotexttmpl
 [
-  // escape from insert mode
-  {
-    "command": "vscode-neovim.compositeEscape1",
-    "key": "j",
-    "when": "neovim.mode == insert && editorTextFocus",
-    "args": "j",
-  },
-  {
-    "command": "vscode-neovim.compositeEscape2",
-    "key": "k",
-    "when": "neovim.mode == insert && editorTextFocus",
-    "args": "k",
-  },
 ]

--- a/home/.chezmoitemplates/common/vscode-keybindings.json.tmpl
+++ b/home/.chezmoitemplates/common/vscode-keybindings.json.tmpl
@@ -1,3 +1,39 @@
 // -*-mode:jsonc-*- vim:ft=jsonc.gotexttmpl
 [
+  // File Exploer works like neotree
+  {
+    "key": "/",
+    "command": "list.find",
+    "when": "listFocus && listSupportsFind"
+  },
+  {
+    "key": "a",
+    "command": "exploer.newFile",
+    "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus"
+  },
+  {
+    "key": "shift+a",
+    "command": "explorer.newFolder",
+    "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus"
+  },
+  {
+    "key": "d",
+    "command": "deleteFile",
+    "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus"
+  },
+  {
+    "key": "s",
+    "command": "explorer.openToSide",
+    "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus"
+  },
+  {
+    "key": "c",
+    "command": "list.expand",
+    "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus"
+  },
+  {
+    "key": "shilft+c",
+    "command": "list.collapse",
+    "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus"
+  },
 ]

--- a/home/.chezmoitemplates/common/vscode-keybindings.json.tmpl
+++ b/home/.chezmoitemplates/common/vscode-keybindings.json.tmpl
@@ -1,5 +1,21 @@
 // -*-mode:jsonc-*- vim:ft=jsonc.gotexttmpl
 [
+  {
+    "key": "cmd+=",
+    "command": "-workbench.action.zoomIn"
+  },
+  {
+    "key": "cmd+-",
+    "command": "-workbench.action.zoomOut"
+  },
+  {
+    "key": "cmd+=",
+    "command": "editor.action.fontZoomIn"
+  },
+  {
+    "key": "cmd+-",
+    "command": "editor.action.fontZoomOut"
+  },
   // File Exploer works like neotree
   {
     "key": "/",

--- a/home/.chezmoitemplates/common/vscode-settings.json.tmpl
+++ b/home/.chezmoitemplates/common/vscode-settings.json.tmpl
@@ -92,7 +92,13 @@
   },
   // NeoVim
   "vscode-neovim.compositeKeys": {
-    "jj": { "command": "vscode-neovim.escape" }
+    "jj": {
+      "command": "vscode-neovim.escape"
+    },
+    "jk": {
+      "command": "vscode-neovim.lua",
+      "args": ["vim.api.nvim_input('<ESC>')\nrequire('vscode-neovim').action('workbench.action.files.save')"]
+    }
   },
   "vscode-neovim.neovimExecutablePaths.darwin": "{{ .brew_prefix }}/bin/nvim",
   "vscode-neovim.neovimInitVimPaths.darwin": "~/.config/nvim/init.lua",

--- a/home/.chezmoitemplates/common/vscode-settings.json.tmpl
+++ b/home/.chezmoitemplates/common/vscode-settings.json.tmpl
@@ -91,6 +91,9 @@
     "**/logs": true,
   },
   // NeoVim
+  "vscode-neovim.compositeKeys": {
+    "jj": { "command": "vscode-neovim.escape" }
+  },
   "vscode-neovim.neovimExecutablePaths.darwin": "{{ .brew_prefix }}/bin/nvim",
   "vscode-neovim.neovimInitVimPaths.darwin": "~/.config/nvim/init.lua",
   "vscode-neovim.neovimExecutablePaths.linux": "{{ .brew_prefix }}/bin/nvim",


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

* remove keybind to escape from insert mode
* define keybind to escape with `vscode-neovim.compositeKeys`
* define keybind to control file explorer
* define keybind to zoom in & out

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #496

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
