### PR TITLE
fix(fish): update locale to run tui app

### DIFF
--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -1,8 +1,8 @@
 # -*-mode:fish-*- vim:ft=fish.gotexttmpl
 
 # Language/Locale Configuration
-set -x LANG ja_JP.UTF-8
-set -x LC_CTYPE ja_JP.UTF-8
+set -x LANG en_US.UTF-8
+set -x LC_CTYPE en_US.UTF-8
 
 # Path Configuration
 fish_add_path {{ .brew_prefix }}/bin


### PR DESCRIPTION
to prevent layout collapse

# Summary
<!-- add the description of the PR here -->

* update locale: `en_US.UTF-8` -> `ja_JP.UTF-8`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #514

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
