### PR TITLE
chore(neovim): move diagnostics on `lualine.nvim` section to winbar

### DIFF
--- a/home/dot_config/nvim/lua/ui/bufferline.lua
+++ b/home/dot_config/nvim/lua/ui/bufferline.lua
@@ -9,12 +9,8 @@ bufferline.setup {
     diagnostics = "nvim_lsp",
 
     -- Format
-    name_formatter = function(opts)
-      return string.format("%s", opts.name)
-    end,
-    numbers = function(opts)
-      return string.format("%s", opts.ordinal)
-    end,
+    name_formatter = function(opts) return string.format("%s", opts.name) end,
+    numbers        = function(opts) return string.format("%s", opts.ordinal) end,
 
     offset = {
       {

--- a/home/dot_config/nvim/lua/ui/lualine.lua
+++ b/home/dot_config/nvim/lua/ui/lualine.lua
@@ -28,7 +28,6 @@ lualine.setup {
     },
     lualine_b = { "branch", "diff" },
     lualine_c = {
-      { "diagnostics", source = { "nvim-lsp", "nvim_diagnostic"} },
       {
         "filename",
         icon = { "", color = { fg = "#FFFFFF" } },
@@ -46,6 +45,10 @@ lualine.setup {
     lualine_z = { "progress", "location" },
   },
   winbar = {
+    lualine_a = {},
+    lualine_b = {
+      { "diagnostics", source = { "nvim-lsp", "nvim_diagnostic"} },
+    },
     lualine_c = {
       {
         function() return navic.get_location() end,


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

* move diagnostics on `lualine.nvim` section to winbar

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #573

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
