### PR TITLE
feat(neovim): update `gitsigns.nvim` options

### DIFF
--- a/home/dot_config/nvim/lua/user/gitsigns.lua
+++ b/home/dot_config/nvim/lua/user/gitsigns.lua
@@ -5,13 +5,13 @@ if not ok then return end
 gitsigns.setup({
   current_line_blame = true,
   signs = {
-    add          = { hl = 'GitSignsAdd'   , text = '✚', numhl='GitSignsAddNr'   , linehl='GitSignsAddLn'},
-    change       = { hl = 'GitSignsChange', text = '↻', numhl='GitSignsChangeNr', linehl='GitSignsChangeLn'},
-    delete       = { hl = 'GitSignsDelete', text = '▁', numhl='GitSignsDeleteNr', linehl='GitSignsDeleteLn'},
-    topdelete    = { hl = 'GitSignsDelete', text = '▔', numhl='GitSignsDeleteNr', linehl='GitSignsDeleteLn'},
-    changedelete = { hl = 'GitSignsChange', text = '—↻', numhl='GitSignsChangeNr', linehl='GitSignsChangeLn'},
+    add          = { text = "┃" },
+    change       = { text = "┃" },
+    delete       = { text = "_" },
+    topdelete    = { text = "‾" },
+    changedelete = { text = "~" },
+    untracked    = { text = "┆" },
   },
-
 })
 
 if vim.g.scrollbar_enabled then


### PR DESCRIPTION
to suppress annoying warning

# Summary
<!-- add the description of the PR here -->

- Update `gitsigns.nvim` options to suppress warning

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #585

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
