### PR TITLE
589 feature update markdown config for neovim

### DIFF
--- a/home/dot_config/nvim/lua/plugins/misc.lua
+++ b/home/dot_config/nvim/lua/plugins/misc.lua
@@ -15,7 +15,6 @@ return {
   -- Translate Engine
   { "potamides/pantran.nvim", cmd = "Pantran", config = function() require("user.pantran") end },
 
-  { "vim-denops/denops.vim" },
   {
     "epwalsh/obsidian.nvim",
     version = "*",

--- a/home/dot_config/nvim/lua/plugins/misc.lua
+++ b/home/dot_config/nvim/lua/plugins/misc.lua
@@ -16,14 +16,6 @@ return {
   { "potamides/pantran.nvim", cmd = "Pantran", config = function() require("user.pantran") end },
 
   { "vim-denops/denops.vim" },
-  -- Markdown Previewer
-  {
-    "kat0h/bufpreview.vim",
-    dependencies = { "vim-denops/denops.vim" },
-    build = "deno task prepare",
-    ft    = "markdown",
-    cmd   = "PreviewMarkdown",
-  },
   {
     "epwalsh/obsidian.nvim",
     version = "*",


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- remove `denops.vim`
- remove `bufpreview.vim`

use `Obsidian.app` for markdown preview

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #589

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
