### PR TITLE
chore(mise): deactivate `python`

### DIFF
--- a/home/.chezmoidata/mise.toml
+++ b/home/.chezmoidata/mise.toml
@@ -21,7 +21,7 @@ enabled  = true
 versions = ["latest"]
 
 [mise.python]
-enabled  = true
+enabled  = false
 versions = ["3.11", "3.12"]
 
 [mise.ruby]


### PR DESCRIPTION
use docker environment instead

# Summary
<!-- add the description of the PR here -->

- change `.mise.python.enabled` value
(use docker environment instread)

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #602

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
