### PR TITLE
feat(neovim): add abbreviation for typo

### DIFF
--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -14,6 +14,16 @@ local nv, nx, nt, nxo, o, ox, c = {"n", "v"}, {"n", "x"}, {"n", "t"}, {"n", "x",
 local ok, wk = pcall(require, "which-key")
 if not ok then vim.notify("Failed loading " .. "which-key", vim.log.levels.WARN) end
 
+-- Abbreviation for typo
+vim.cmd[[
+  cnoreabbrev Q q
+  cnoreabbrev q1 q!
+  cnoreabbrev Q1 q!
+  cnoreabbrev W w
+  cnoreabbrev Wq wq
+  cnoreabbrev WQ wq
+]]
+
 ---------------------------------------------------------------------------
 -- which-key commands
 ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- configure cmdline abbrev with `cnoreabbrev` for typo

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #628

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
