### PR TITLE
feat(neovim): update autocmd config

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -17,13 +17,6 @@ local highlight_url = function()
 end
 
 autocmd("BufWritePre", {
-  desc    = "Strip trailing whitespace ",
-  group   = augroup "TrailStripper",
-  pattern = "*",
-  command = "%s/s+$//e",
-})
-
-autocmd("BufWritePre", {
   desc    = "Strip trailing new lines at the end of file on save",
   group   = augroup "TrailStripper",
   pattern = "*",

--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -23,6 +23,14 @@ autocmd("BufWritePre", {
   command = ":%s/\\n\\+\\%$//e",
 })
 
+autocmd({ "BufWinEnter" }, {
+  desc     = "Open :help with vertical split",
+  pattern  = "*.txt",
+  callback = function()
+    if vim.bo.filetype == "help" then vim.cmd.wincmd("L") end
+  end
+})
+
 autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
   desc    = "Check if we need to reload the file when it changed",
   group   = augroup("checktime"),

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -38,9 +38,7 @@ wk.add({
 -- ❓ Help: <Leader> + H
 ---------------------------------------------------------------------------
 wk.add({
-  { "<Leader>h", group = "Help", icon = "❓ " },
-  { "<Leader>hh", ":horizontal above help<Space>",    icon = " ", desc = "Open Help page above buffer" },
-  { "<Leader>hv", ":vertical belowright help<Space>", icon = " ", desc = "Open Help page right side" },
+  { "<Leader>h", ":help<Space>", icon = "❓ ", desc = "Open Help page" },
 }, opts)
 
 ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- remove duplicated config: strip trailing space
use `builtin.diagnostics.trail_space` function in `none-ls.nvim`

- open help with vertical split everytime

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #737

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
