### PR TITLE
feat(neovim): update help config

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -25,7 +25,7 @@ autocmd("BufWritePre", {
 
 autocmd({ "BufWinEnter" }, {
   desc     = "Open :help with vertical split",
-  pattern  = "*.txt",
+  pattern  = { "*.txt", "*.jax" },
   callback = function()
     if vim.bo.filetype == "help" then vim.cmd.wincmd("L") end
   end

--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -1,7 +1,7 @@
 -- -*-mode:lua-*- vim:ft=lua
 
 return {
-  { "vim-jp/vimdoc-ja", ft = "help" },
+  { "vim-jp/vimdoc-ja", event = { "CmdlineEnter" } },
   {
     "akinsho/toggleterm.nvim",
     cond   = not vim.g.vscode,


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Update `vim-jp/vimdoc-ja` loading condition
- add `jax` as filetype for help to open help vertically

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #747

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
