### PR TITLE
feat(neovim): replace colorizer plugin

### DIFF
--- a/home/dot_config/nvim/lua/plugins/appearance.lua
+++ b/home/dot_config/nvim/lua/plugins/appearance.lua
@@ -6,8 +6,7 @@ return {
   { "navarasu/onedark.nvim",  config = function() require("ui.onedark") end },
 
   {
-    "NvChad/nvim-colorizer.lua", -- Color code viewer
-    -- event  = { "BufReadPost", "BufNewFile" },
+    "catgoose/nvim-colorizer.lua",-- Color code viewer
     cmd = { "ColorizerToggle" },
     config = function() require("ui.colorizer") end,
   },


### PR DESCRIPTION
`NvChad/colorizer.lua` -> `catgoose/nvim-colorizer.lua`

# Summary
<!-- add the description of the PR here -->

- [x] Replace colorizer plugin [`NvChad/colorizer.lua`][NvChad] -> [`catgoose/nvim-colorizer.lua`][catgoose]

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #798

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
