### PR TITLE
feat: add missing zellij config

### DIFF
--- a/home/dot_config/nushell/functions/mod.nu
+++ b/home/dot_config/nushell/functions/mod.nu
@@ -3,3 +3,4 @@
 export use ls.nu *
 export use ghq.nu *
 export use nvim.nu *
+export use zellij.nu *

--- a/home/dot_config/nushell/functions/zellij.nu
+++ b/home/dot_config/nushell/functions/zellij.nu
@@ -1,0 +1,26 @@
+# -*-mode:nu-*- vim:ft=nu
+
+export def zld [] {
+    zellij --layout default
+}
+
+export def zlc [] {
+    zellij --layout config
+}
+
+export def zlj [] {
+    zellij --layout jsdev
+}
+
+export def zlm [] {
+    zellij --layout monitor
+}
+
+export def zls [] {
+    zellij attach (zellij list-sessions | fzf --ansi | awk 'print $1')
+}
+
+export def zll [] {
+    let layout = (fd . $'($env.XDG_CONFIG_HOME)/zellij/layouts' --full-path --min-depth=1 --max-depth=1 --extension kdl | fzf --ansi)
+    zellij --layout $layout
+}

--- a/home/dot_config/zellij/config.kdl.tmpl
+++ b/home/dot_config/zellij/config.kdl.tmpl
@@ -1,6 +1,6 @@
 // -*-mode:kdl-*- vim:ft=kdl.gotexttmpl
 // If you'd like to override the default keybindings completely, be sure to change "keybinds" to "keybinds clear-defaults=true"
-keybinds {
+keybinds clear-defaults=true {
     normal {
         // uncomment this and adjust key if using copy_on_select=false
         // bind "Alt c" { Copy; }

--- a/home/dot_config/zsh/functions/zellij.zsh
+++ b/home/dot_config/zsh/functions/zellij.zsh
@@ -21,7 +21,7 @@ function zellij-session() {
 }
 
 function zellij-layout() {
-  local layout_dir="$XDG_DATA_HOME/zellij/layouts"
+  local layout_dir="$XDG_CONFIG_HOME/zellij/layouts"
   local layout="$(fd . ${layout_dir} --full-path -min-depth=1 --max-depth=1 --extension kdl | fzf --ansi)"
   [ -n "$layout" ] && zellij --layout $layout
   zle accept-line


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Fix layout path
- Add `zellij` shorten command
- Disable default keybind with `clear-defaults=true` option

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #820

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
