### PR TITLE
feat(neovim): add `svelte` filetype as javascript

### DIFF
--- a/home/dot_config/nvim/lua/user/filetypes.lua
+++ b/home/dot_config/nvim/lua/user/filetypes.lua
@@ -8,7 +8,7 @@ Filetypes.lang = {
   shell = { "sh",  "bash", "zsh" },
   go    = { "go", "gomod", "gosum", "templ", "gotempl" },
   json  = { "json",  "json5", "jsonc" },
-  js    = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
+  js    = { "javascript", "javascriptreact", "typescript", "typescriptreact", "svelte" },
 }
 
 Filetypes.treesitter = {
@@ -21,7 +21,7 @@ Filetypes.treesitter = {
   -- Script Languages
   "perl", "php", "python", "requirements", "ruby", "lua", "luadoc", "vim", "r", "matlab",
   -- Javascript
-  "javascript", "typescript", "tsx", "vue",
+  "javascript", "typescript", "tsx", "vue", "svelte",
   "json", "json5", "jsonc", "jsdoc", "jq",
   -- Markup Languages
   "html", "css", "scss",


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Add filetype `svelte` as javascript
- Add treesitter `svelte` parser


## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #867

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
