### PR TITLE
feat(neovim): update snacks.nvim config

### DIFF
--- a/home/dot_config/nvim/lua/core/ignore.lua
+++ b/home/dot_config/nvim/lua/core/ignore.lua
@@ -7,7 +7,7 @@ end
 
 return {
   files = files,
-  autopairs  = { "fzf", "vim" },
+  autopairs  = { "fzf", "vim", "snacks_picker_input" },
   illuminate = { "alpha", "lazy", "oil", "fzf", "toggleterm", "Trouble", "codecompnion" },
 
   lualine = {

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -182,11 +182,12 @@ if not is_vscode then
     { "<Leader>fw", "<CMD>lua Snacks.picker.grep_word()<CR>", mode = nx, icon = " ", desc = "grep with cword" },
 
     -- Vim
-    { "<Leader>fh", "<CMD>lua Snacks.picker.help()<CR>",      icon = " ", desc = "Help" },
-    { "<Leader>fq", "<CMD>lua Snacks.picker.qflist()<CR>",    icon = " ", desc = "Quickfix list" },
-    { "<Leader>fa", "<CMD>lua Snacks.picker.autocmds()<CR>",  icon = " ", desc = "autocmds list" },
-    { "<Leader>fr", "<CMD>lua Snacks.picker.registers()<CR>", icon = " ", desc = "Register list" },
-    { "<Leader>fu", "<CMD>lua Snacks.picker.undo()<CR>",      icon = " ", desc = "Undo Tree" },
+    { "<Leader>fh", "<CMD>lua Snacks.picker.help()<CR>",       icon = " ", desc = "Help" },
+    { "<Leader>fq", "<CMD>lua Snacks.picker.qflist()<CR>",     icon = " ", desc = "Quickfix list" },
+    { "<Leader>fa", "<CMD>lua Snacks.picker.autocmds()<CR>",   icon = " ", desc = "autocmds list" },
+    { "<Leader>fr", "<CMD>lua Snacks.picker.registers()<CR>",  icon = " ", desc = "Register list" },
+    { "<Leader>fu", "<CMD>lua Snacks.picker.undo()<CR>",       icon = " ", desc = "Undo Tree" },
+    { "<Leader>fH", "<CMD>lua Snacks.picker.highlights()<CR>", icon = " ", desc = "Hilight list" },
 
     -- Git
     { "<Leader>gf", "<CMD>lua Snacks.picker.git_files()<CR>",  icon = " ", desc = "Git Files" },

--- a/home/dot_config/nvim/lua/core/theme.lua
+++ b/home/dot_config/nvim/lua/core/theme.lua
@@ -2,3 +2,7 @@
 
 -- Color Schemes
 vim.cmd.colorscheme(vim.g.colorscheme)
+
+local palette = require("onedark.palette")[vim.g.themestyle]
+vim.api.nvim_set_hl(0, "SnacksPickerDir",        { fg = palette.cyan })
+vim.api.nvim_set_hl(0, "SnacksPickerPathHidden", { fg = palette.bg3 })

--- a/home/dot_config/nvim/lua/ui/zen.lua
+++ b/home/dot_config/nvim/lua/ui/zen.lua
@@ -4,7 +4,7 @@
 return {
   enabled = true,
   toggles = {
-    dim             = true,
+    dim             = false,
     git_signs       = true,
     mini_diff_signs = false,
   },

--- a/home/dot_config/nvim/lua/user/snacks.lua
+++ b/home/dot_config/nvim/lua/user/snacks.lua
@@ -28,5 +28,5 @@ snacks.setup({
 })
 
 vim.api.nvim_create_user_command("SnacksPickerLazyPlugin", function()
-  Snacks.picker.smart({ cwd = vim.fn.stdpath("data") .. "/lazy" })
+  require("snacks.picker").smart({ cwd = vim.fn.stdpath("data") .. "/lazy" })
 end, { desc = "", nargs = "*", bang = true })

--- a/home/dot_config/nvim/lua/user/snacks.lua
+++ b/home/dot_config/nvim/lua/user/snacks.lua
@@ -26,3 +26,7 @@ snacks.setup({
     },
   }
 })
+
+vim.api.nvim_create_user_command("SnacksPickerLazyPlugin", function()
+  Snacks.picker.smart({ cwd = vim.fn.stdpath("data") .. "/lazy" })
+end, { desc = "", nargs = "*", bang = true })


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Disable `nvim-autopairs` in `Snacks.picker` input
- Disable dim mode on `Snacks.zen`
- Add `Snacks.picker` path highlights
- Add `Snacks.picker` command to search nvim plugin installed by `lazy.nvim`
- Add `Snacks.picker` command to search nvim highlights

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #919

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
