### PR TITLE
feat(neovim): update deprecated lsp config

### DIFF
--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -1,5 +1,5 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not (vim.uv or vim.loop).fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   local lazyrepo = "https://github.com/folke/lazy.nvim.git"
   local out = vim.fn.system({ "git", "clone", "--filter=blob:none", lazyrepo, "--branch=stable", lazypath })
   if vim.v.shell_error ~= 0 then

--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -132,9 +132,9 @@ autocmd({ "LspAttach" }, {
     vim.keymap.set("n", "gr", vim.lsp.buf.references,     extend("force", bufopts, { desc = "References" }))
     vim.keymap.set("n", "ga", vim.lsp.buf.code_action,    extend("force", bufopts, { desc = "Code Action" }))
 
-    -- Format on save
     local client = vim.lsp.get_client_by_id(ev.data.client_id)
-    if client ~= nil and client.supports_method("textDocument/formatting") then
+    -- Format on save
+    if client ~= nil and client:supports_method("textDocument/formatting", ev.buf) then
       vim.api.nvim_create_autocmd({ "BufWritePre" }, {
         desc     = "Format on save via LSP",
         group    = augroup("UserLspConfig"),

--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -48,7 +48,7 @@ autocmd("TextYankPost", {
   desc     = "Highlight on yank",
   group    = augroup("highlight_yank"),
   pattern  = "*",
-  callback = function(_) vim.highlight.on_yank() end,
+  callback = function(_) vim.hl.on_yank() end,
 })
 
 autocmd("FileType", {

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -238,8 +238,9 @@ wk.add({
   { "<Leader>l", group = "LSP", icon = "🚦 " },
   { "<Leader>li", "<CMD>lua Snacks.picker.lsp_config()<CR>", icon = " ", desc = "Display LSP Info" },
 
-  { "g[",  "<CMD>lua vim.diagnostic.goto_prev()<CR>",    icon = " ", desc = "Go to prev diagnostics" },
-  { "g]",  "<CMD>lua vim.diagnostic.goto_next()<CR>",    icon = " ", desc = "Go to next diagnostics" },
+  { "g[",  "<CMD>lua vim.diagnostic.jump({count=-1,float=true })<CR>", icon = " ", desc = "Go to prev diagnostics" },
+  { "g]",  "<CMD>lua vim.diagnostic.jump({count=1, float=true })<CR>", icon = " ", desc = "Go to next diagnostics" },
+
   { "gn",  "<CMD>lua vim.lsp.buf.rename()<CR>",          icon = " ", desc = "Rename" },
   { "gci", "<CMD>lua vim.lsp.buf.incoming_calls()<CR>",  icon = " ", desc = "Call incoming hierarchy" },
   { "gco", "<CMD>lua vim.lsp.buf.outcoming_calls()<CR>", icon = " ", desc = "Call outcoming hierarchy" },

--- a/home/dot_config/nvim/lua/debugger/adapters/delve.lua
+++ b/home/dot_config/nvim/lua/debugger/adapters/delve.lua
@@ -14,7 +14,7 @@ return function(callback, config)
     detected = true,
   }
 
-  handle, pid_or_err = vim.loop.spawn("dlv", opts, function(code)
+  handle, pid_or_err = vim.uv.spawn("dlv", opts, function(code)
     if stdout ~= nil and stderr ~= nil then
       stdout:close()
       stderr:close()

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -1,9 +1,6 @@
 -- -*-mode:lua-*- vim:ft=lua
 
-vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
-  border = "rounded",
-})
-
+vim.lsp.handlers["textDocument/hover"]         = vim.lsp.with(vim.lsp.buf.hover, { border = "rounded" })
 vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
   border = "rounded",
   silent = true,

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -1,7 +1,7 @@
 -- -*-mode:lua-*- vim:ft=lua
 
 vim.lsp.handlers["textDocument/hover"]         = vim.lsp.with(vim.lsp.buf.hover, { border = "rounded" })
-vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
+vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.buf.signature_help, {
   border = "rounded",
   silent = true,
   -- focusable = false,

--- a/home/dot_config/nvim/lua/lsp/config/null-ls.lua
+++ b/home/dot_config/nvim/lua/lsp/config/null-ls.lua
@@ -24,7 +24,7 @@ local lsp_formatting = function(bufnr)
 end
 
 local on_attach = function(client, bufnr)
-  if client.supports_method("textDocument/formatting") then
+  if client:supports_method("textDocument/formatting", bufnr) then
     api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
     api.nvim_create_autocmd("BufWritePre", {
       group = augroup,


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Update deprecated LSP config in [DEPRECATED IN 0.11](https://neovim.io/doc/user/deprecated.html#deprecated-0.11)
  - `client.supports_method` -> `client:supports_method`
  - `vim.diagnostic.goto_*` -> `vim.diagnostic.jump`
  - `vim.loop` -> `vim.uv`
  - `vim.highlight` -> `vim.hl`
  - `vim.lsp.handlers.hover` -> `vim.lsp.buf.hover`
  - `vim.lsp.handlers.signature_help` -> `vim.lsp.buf.signature_help`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #965

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
