### PR TITLE
fix(neovim): wrong executable name for `html-lsp`

### DIFF
--- a/home/dot_config/nvim/lua/lsp/servers/html.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/html.lua
@@ -2,7 +2,7 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd          = { "html-languageserver", "--stdio" },
+  cmd          = { "vscode-html-languageserver", "--stdio" },
   filetypes    = { "html", "eruby" },
   root_markers = { "package.json", ".git" },
   single_file_support = true,


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Fix `html-lsp` executable name

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #999

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
