### PR TITLE
feat(neovim): update lspconfig to follow `mason-lspconfig` version 2.x

### DIFF
--- a/home/dot_config/nvim/lua/lsp/config/init.lua
+++ b/home/dot_config/nvim/lua/lsp/config/init.lua
@@ -60,16 +60,14 @@ end
 local servers = require("lsp.servers")
 mason_cfg.setup({
   ensure_installed = servers,
-  automatic_installation = true,
+  automatic_enable = true,
 })
 
 local server_opts = {
   on_attach    = on_attach,
   capabilities = require("lsp.config.capabilities"),
 }
-mason_cfg.setup_handlers {
-  function (server)
-    vim.lsp.config(server, vim.tbl_deep_extend("force", server_opts, servers[server] or {}))
-    vim.lsp.enable(server)
-  end,
-}
+for server, _ in pairs(servers) do
+  vim.lsp.config(server, vim.tbl_deep_extend("keep", server_opts, servers[server] or {}))
+  -- vim.lsp.enable(server)
+end


### PR DESCRIPTION
removed `setup_handlers`, `automatic_installation`

# Summary
<!-- add the description of the PR here -->

- Update `mason-lspconfig` config to follow version 2.x

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1009

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
