### PR TITLE
feat: update markdownlint config

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -6,6 +6,7 @@ MD004: false # Unordered list style
 MD010: false # Hard tabs
 MD012: false # no-multiple-blanks - Multiple consecutive blank lines
 MD013: false # line-length - Line length
+MD022: false # Headings should be surrounded by blank lines
 MD024: false # no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD033: false # no-inline-html - Inline HTML
 MD034: false # Bare URL used

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -9,6 +9,7 @@ MD013: false # line-length - Line length
 MD022: false # Headings should be surrounded by blank lines
 MD024: false # no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD031: false # Fenced code blocks should be surrounded by blank lines
+MD032: false # Lists should be surrounded by blank
 MD033: false # no-inline-html - Inline HTML
 MD034: false # Bare URL used
 MD041: false # first-line-heading/first-line-h1 - First line in a file should be a top-level heading

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -8,6 +8,7 @@ MD012: false # no-multiple-blanks - Multiple consecutive blank lines
 MD013: false # line-length - Line length
 MD022: false # Headings should be surrounded by blank lines
 MD024: false # no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD031: false # Fenced code blocks should be surrounded by blank lines
 MD033: false # no-inline-html - Inline HTML
 MD034: false # Bare URL used
 MD041: false # first-line-heading/first-line-h1 - First line in a file should be a top-level heading


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

-  Disable `MD022` (Headings should be surrounded by blank lines)
-  Disable `MD031` (Fenced code blocks should be surrounded by blank lines)
-  Disable `MD032` (Lists should be surrounded by blank)

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1127

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
