### PR TITLE
feat(neovim): remove `codecompanion.nvim` integration for `blink.cmp`

### DIFF
--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -37,7 +37,7 @@ blink.setup({
   signature = { enabled = true }, -- Experimental option
 
   sources = {
-    default = { "lsp", "lazydev", "path", "buffer", "snippets", "markdown", "codecompanion" },
+    default = { "lsp", "lazydev", "path", "buffer", "snippets", "markdown" },
 
     providers = {
       lsp      = { min_keyword_length = function(ctx) return ctx.trigger.kind == "manual" and 0 or 2  end },
@@ -48,7 +48,6 @@ blink.setup({
       -- Third party plugin integration
       lazydev       = { name = "LazyDev",        module = "lazydev.integrations.blink",  fallbacks = { "lazy_dev" } },
       markdown      = { name = 'RenderMarkdown', module = 'render-markdown.integ.blink', fallbacks = { 'lsp' } },
-      codecompanion = { name = "CodeCompanion",  module = "codecompanion.providers.completion.blink" },
     },
   },
 


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Remove `codecompanion.nvim` integration for `blink.cmp`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1157

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
