### PR TITLE
feat(neovim): disable `oil.nvim` in terminal mode

### DIFF
--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -373,7 +373,7 @@ end
 -----------------------------------------------------------------------
 if not is_vscode then
   wk.add({
-    mode = nt,
+    mode = "n",
     { "-",         "<CMD>Oil<CR>",         icon = " ", desc = "Open Parent Dir" },
     { "<Leader>e", "<CMD>Oil<CR>",         icon = " ", desc = "Open Parent Dir" },
     { "<Leader>E", "<CMD>Oil --float<CR>", icon = " ", desc = "Open Parent Dir w/ float mode" },


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- disable `oil.nvim` in terminal mode

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1161

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
