### PR TITLE
feat(ai): update `blink.cmp` deprecated adapter config

### DIFF
--- a/home/dot_config/nvim/lua/ai/codecompanion/adapters/init.lua
+++ b/home/dot_config/nvim/lua/ai/codecompanion/adapters/init.lua
@@ -1,11 +1,13 @@
 -- -*-mode:lua-*- vim:ft=lua
 
 return {
-  groq      = require("ai.codecompanion.adapters.groq"),
-  copilot   = require("ai.codecompanion.adapters.copilot"),
-  openai    = require("ai.codecompanion.adapters.openai"),
-  anthropic = require("ai.codecompanion.adapters.anthropic"),
-  google    = require("ai.codecompanion.adapters.google"),
-  qwen      = require("ai.codecompanion.adapters.qwen"),
-  ollama    = require("ai.codecompanion.adapters.ollama"),
+  http = {
+    groq      = require("ai.codecompanion.adapters.groq"),
+    copilot   = require("ai.codecompanion.adapters.copilot"),
+    openai    = require("ai.codecompanion.adapters.openai"),
+    anthropic = require("ai.codecompanion.adapters.anthropic"),
+    google    = require("ai.codecompanion.adapters.google"),
+    qwen      = require("ai.codecompanion.adapters.qwen"),
+    ollama    = require("ai.codecompanion.adapters.ollama"),
+  },
 }


### PR DESCRIPTION
deprecate in 18.x

# Summary
<!-- add the description of the PR here -->

- Update `blink.cmp` deprecated adapter config

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1165

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
