### PR TITLE
feat(neovim): update lsp config

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -102,9 +102,10 @@ vim.api.nvim_create_autocmd({ "QuickFixCmdPost" }, {
   end,
 })
 
+local lsp_augroup = augroup("UserLspGroup")
 vim.api.nvim_create_autocmd({ "LspAttach" }, {
   desc     = "LSP Actions (keymaps, auto format)",
-  group    = augroup("UserLspConfig"),
+  group    = lsp_augroup,
   callback = function(ev)
     -- Configure LSP related keymap
     local bufopts = { noremap = true, silent = true, buffer = ev.buf }
@@ -135,9 +136,10 @@ vim.api.nvim_create_autocmd({ "LspAttach" }, {
 
     -- Format on save
     if client ~= nil and client:supports_method("textDocument/formatting", ev.buf) then
+      vim.api.nvim_clear_autocmds({ group = lsp_augroup, buffer = ev.buf })
       vim.api.nvim_create_autocmd({ "BufWritePre" }, {
         desc     = "Format on save via LSP",
-        group    = augroup("UserLspConfig"),
+        group    = lsp_augroup,
         callback = require("lsp.config.format"),
       })
     end

--- a/home/dot_config/nvim/lua/lsp/servers/jsonls.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/jsonls.lua
@@ -10,47 +10,7 @@ return {
 
   settings = {
     json = {
-      schemas = {
-        { fileMatch = { "package.json" },  url = "https://www.schemastore.org/package.json" },
-        { fileMatch = { "tsconfig.json" }, url = "https://www.schemastore.org/tsconfig.json" },
-        { fileMatch = { "turbo.json" },    url = "https://turborepo.com/schema.json" },
-        {
-          fileMatch = { "renovate.json", "renovate.json5", },
-          url = "https://docs.renovatebot.com/renovate-schema.json",
-        },
-        {
-          fileMatch = { "biome.json", "biome.jsonc" },
-          url = "https://biomejs.dev/schemas/latest/schema.json",
-        },
-        {
-          fileMatch = { ".prettierrc", ".prettierrc.json", "prettier.config.json" },
-          url = "https://www.schemastore.org/prettierrc.json",
-        },
-        {
-          fileMatch = { ".eslintrc", ".eslintrc.json" },
-          url = "https://www.schemastore.org/eslintrc.json",
-        },
-        {
-          fileMatch = { ".lintstagedrc", ".lintstagedrc.json" },
-          url = "https://www.schemastore.org/lintstagedrc.schema.json",
-        },
-        {
-          fileMatch = { ".commitlintrc", "commitlintrc.json" },
-          url = "https://www.schemastore.org/commitlintrc.json",
-        },
-        {
-          fileMatch = { ".huskyrc", ".huskyrc.json" },
-          url = "https://www.schemastore.org/huskyrc.json",
-        },
-        {
-          fileMatch = { "now.json", "vercel.json" },
-          url = "https://www.schemastore.org/now.json",
-        },
-        {
-          fileMatch = { "settings.json" },
-          url = "https://www.schemastore.org/claude-code-settings.json",
-        },
-      },
+      schemas    = require("schemastore").json.schemas(),
       format     = { enable = false, singleQuote = false },
       validate   = { enable = true },
       completion = true,

--- a/home/dot_config/nvim/lua/lsp/servers/rubocop.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/rubocop.lua
@@ -2,7 +2,7 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd          = { "rubocop", "-lsp" },
+  cmd          = { "rubocop", "--lsp" },
   filetypes    = { "ruby" },
   root_markers = require("user.filetypes").lsp.ruby,
   single_file_support = true,

--- a/home/dot_config/nvim/lua/lsp/servers/ruby_ls.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/ruby_ls.lua
@@ -34,7 +34,8 @@ return {
       "completion",
       "codeLens",
     },
-    formatter = "none", ---@type "none"|"rubocop"
+    formatter = "rubocop", ---@type "auto"|"none"|"rubocop"
+    linter    = "rubocop", ---@type "auto"|"none"|"rubocop"
   },
   settings = {},
   -- commands = {

--- a/home/dot_config/nvim/lua/lsp/servers/yamlls.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/yamlls.lua
@@ -9,8 +9,8 @@ return {
     -- https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting
     redhat = { telemetry = { enabled = false } },
     yaml = {
+      schemas     = require("schemastore").yaml.schemas(),
       keyOrdering = false,
-      schemastore = { enabled = true, url = "https://www.schemastore.org/api/json/catalog.json" },
       format      = { enabled = true, singleQuote = false },
       validate    = true,
       completion  = true,

--- a/home/dot_config/nvim/lua/plugins/lsp.lua
+++ b/home/dot_config/nvim/lua/plugins/lsp.lua
@@ -27,4 +27,5 @@ return {
     cmd    = { "Trouble" },
     config = function() require("lsp.config.trouble") end,
   },
+  { "b0o/schemastore.nvim" },
 }


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Reactivate `schemastore.nvim`; too hard to maintain manually
- Activate `rubocop` integration for `ruby-lsp`
- Change `none-ls` augroup name to prevent conflicting with `LspFormatting` which is default
- add `vim.api.nvim_clear_autocmds` when lsp format on save


## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1175

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->