### PR TITLE
feat(neovim): update octo.nvim config

### DIFF
--- a/home/dot_config/nvim/lua/plugins/ai.lua
+++ b/home/dot_config/nvim/lua/plugins/ai.lua
@@ -7,13 +7,6 @@ return {
     dependencies = {
       "nvim-lua/plenary.nvim",
       "nvim-treesitter/nvim-treesitter",
-
-      -- Optional plugins
-      {
-        "MeanderingProgrammer/render-markdown.nvim",
-        ft = { "markdown", "markdown.mdc", "markdown.mdx", "vimwiki", "codecompanion" },
-        config = require("user.render-markdown"),
-      },
     },
     cond = not vim.g.vscode,
     cmd = {

--- a/home/dot_config/nvim/lua/plugins/misc.lua
+++ b/home/dot_config/nvim/lua/plugins/misc.lua
@@ -12,6 +12,11 @@ return {
     cond   = not vim.g.vscode,
     config = function() require("user.octo") end,
   },
+  {
+    "MeanderingProgrammer/render-markdown.nvim",
+    ft = { "markdown", "markdown.mdc", "markdown.mdx", "vimwiki", "octo", "codecompanion" },
+    config = require("user.render-markdown"),
+  },
   -- chezmoi integration
   {
     "xvzc/chezmoi.nvim",

--- a/home/dot_config/nvim/lua/user/octo.lua
+++ b/home/dot_config/nvim/lua/user/octo.lua
@@ -25,6 +25,29 @@ octo.setup({
     copy_url        = { lhs = "<C-y>", desc = "Copy url to system clipboard" },
     checkout_pr     = { lhs = "<C-o>", desc = "Checkout pull request" },
     merge_pr        = { lhs = "<C-r>", desc = "Merge pull request" },
+    snacks = {
+      actions = {
+        issues = {
+          -- {
+          --   name = "my_issue_action",
+          --   fn = function(picker, item) print("Issue action:", vim.inspect(item)) end,
+          --   lhs = "<leader>a",
+          --   desc = "My custom issue action",
+          -- },
+        },
+        pull_requests = {
+          -- {
+          --   name = "my_pr_action",
+          --   desc = "My custom PR action",
+          --   fn = function(picker, item) print("PR action:", vim.inspect(item)) end,
+          --   lhs = "<localleader>b",
+          -- },
+        },
+        notifications = {},
+        issue_templates = {},
+        search = {}
+      },
+    },
   },
 
   colors = {


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Add `octo` filetype config to make `render-markdown.nvim` works
- Add `snacks.nvim` specific config to define custom action later

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1179

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
