### PR TITLE
feat(neovim): remove `nvim-treesitter-endwise` plugin and config

### DIFF
--- a/home/dot_config/nvim/lua/plugins/treesitter.lua
+++ b/home/dot_config/nvim/lua/plugins/treesitter.lua
@@ -8,6 +8,7 @@ return {
       { "nvim-treesitter/nvim-treesitter-textobjects", config = function() require"user.treesitter.textobjects" end },
       { "RRethy/nvim-treesitter-textsubjects",         config = function() require"user.treesitter.textsubjects" end },
     },
+    lazy   = false,
     build  = function() if #vim.api.nvim_list_uis() ~= 0 then vim.api.nvim_command("TSUpdate") end end,
     event  = { "BufReadPost", "BufNewFile" },
     config = function() require("user.treesitter") end,
@@ -19,7 +20,6 @@ return {
     config = function() require("ui.rainbow-delimiters") end,
   },
   { "windwp/nvim-ts-autotag",         ft = filetypes.autotag },
-  { "RRethy/nvim-treesitter-endwise", ft = filetypes.endwise },
   { "andymass/vim-matchup",           ft = filetypes.matchup },
   {
     "numToStr/Comment.nvim",

--- a/home/dot_config/nvim/lua/user/filetypes.lua
+++ b/home/dot_config/nvim/lua/user/filetypes.lua
@@ -72,8 +72,6 @@ Filetypes.autotag = {
   "javascriptreact", "typescriptreact", "markdown",
 }
 
-Filetypes.endwise = { "lua", "vim", "ruby", "elixir", "bash", "fish" }
-
 Filetypes.matchup = {
   "sh", "bash", "csh", "zsh",
   "vim", "lua",

--- a/home/dot_config/nvim/lua/user/treesitter/init.lua
+++ b/home/dot_config/nvim/lua/user/treesitter/init.lua
@@ -22,7 +22,6 @@ treesitter.setup({
   },
   autopairs = enable,
   autotag   = enable,
-  endwise   = enable,
   matchup   = {
     enable  = true,
     include_match_words = true,


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Remove `RRethy/nvim-treesitter-endwise` & config

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1185

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
