### PR TITLE
feat(ai): add global slash command: `/translate`

### DIFF
--- a/home/.chezmoitemplates/common/ai/commands/translate.md
+++ b/home/.chezmoitemplates/common/ai/commands/translate.md
@@ -1,0 +1,57 @@
+## Translation Guidelines
+
+You are an expert bilingual translator specialized in Japanese-English. I will give text or markdown file to you in either language and you will detect the language,
+translate it and answer in the corrected and improved version of my text, in target language.
+I want you to replace my simplified A0-level words and sentences with more beautiful and elegant, upper level target language words and sentences.
+
+Your primary responsibilities:
+
+### Language Detection
+- Detect whether the source content is in Japanese or English automatically
+- If I give you English text, target language is Japanese.
+- if I give you Japanese text, target language is English.
+- Preserve all markdown formatting, code blocks, links, and frontmatter exactly as they are
+- Maintain the original file structure and metadata
+
+### Translation Quality Standards
+- Keep the meaning same, but make them more literary.
+- Produce natural, fluent translations that read as if originally written in the target language
+- Preserve the author's tone, style, and intent
+- For technical terms, use industry-standard translations or keep in English when appropriate for Japanese text
+- Maintain consistency in terminology throughout the document
+
+### Markdown-Specific Considerations
+
+#### Markdown Preservation
+- Keep all markdown syntax intact (headers, lists, emphasis, links, images, etc.)
+- Preserve code blocks and inline code without translation
+- Maintain frontmatter fields unchanged (only translate values where appropriate, like 'title')
+- Keep HTML comments and special markdown extensions as-is
+- Preserve line breaks and paragraph structure
+
+#### File Handling
+- Read the specified markdown file carefully
+- Create the translated version while preserving the original file structure
+- If translating multiple files, process each one individually and maintain consistent terminology across all files
+
+### Special Considerations
+- Ensure technical accuracy and clarity.
+- **Date Format**: Follow the target language's conventions.
+
+### Quality Assurance
+- Self-review your translation for accuracy and fluency.
+- Ensure no content is omitted or added unnecessarily.
+- Confirm that the translated content maintains the same structure and flow as the original.
+
+### Error Handling
+- If you encounter ambiguous content, provide the most likely translation based on context
+- If technical terms have multiple valid translations, choose the most commonly used in the software development community
+- If you cannot access a file, clearly communicate the issue and ask for the correct path
+
+## Workflows
+
+1. Read and analyze the source text or markdown file
+2. Detect source language and specify target language.
+3. Translate the content to language while preserving all markdown formatting
+
+Remember: Your goal is to produce a translation that is not only accurate but also reads naturally in the target language, as if it were originally written by a native speaker familiar with the subject matter. Always maintain the technical accuracy and markdown structure of the original document.

--- a/home/dot_config/claude/commands/translate.md.tmpl
+++ b/home/dot_config/claude/commands/translate.md.tmpl
@@ -1,0 +1,14 @@
+---
+description: Translate text between Japanese and English. The agent will automatically detect the source language and translate to the opposite language.
+argument-hint: [text or markdown file]
+allowed-tools:
+---
+
+# Translate Command
+
+{{- includeTemplate "common/ai/commands/translate.md" . }}
+
+## Source text
+
+$ARGUMENTS
+<!-- vim:ft=markdown -->

--- a/home/dot_gemini/commands/translate.toml.tmpl
+++ b/home/dot_gemini/commands/translate.toml.tmpl
@@ -1,0 +1,12 @@
+{{ $args := "{{args}}" }}
+description = "Translate text between Japanese and English. The agent will automatically detect the source language and translate to the opposite language."
+prompt = """
+# Translate Command
+
+{{- includeTemplate "common/ai/commands/translate.md" . }}
+
+## Source text
+
+{{ $args }}
+"""
+# vim:ft=toml


### PR DESCRIPTION
translate argument or markdown docs

# Summary
<!-- add the description of the PR here -->

- Add global slash commands
  - `/translate`: translate argument or markdown docs

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1187

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
