### PR TITLE
fix(neovim): wrong `chezmoi.nvim` config

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -83,7 +83,7 @@ vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost", "InsertEnter", "CmdlineEn
 
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
   desc     = "Surveillance chezmoi target files",
-  pattern  = { vim.fn.stdpath("data") .. "/chezmoi/*" },
+  pattern  = { os.getenv("HOME") .. "/.local/share/chezmoi/*" },
   callback = function() vim.schedule(require("chezmoi.commands.__edit").watch) end,
 })
 


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Fix `chezmoi.nvim` autocmd config

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1201

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
