### PR TITLE
feat(neovim): add filetype to ignore `flash.nvim`

### DIFF
--- a/home/dot_config/nvim/lua/core/ignore.lua
+++ b/home/dot_config/nvim/lua/core/ignore.lua
@@ -14,7 +14,10 @@ return {
     statusline = { "alpha", "dashboard", "lazy" },
     winbar     = { "alpha", "dashboard", "dapui*", "Trouble", "oil" },
   },
-  flash = { "flash_prompt", "notify", "noice", "oil", "cmp_menu" },
+  flash = {
+    "flash_prompt", "notify", "noice", "oil", "cmp_menu", "blink-cmp-menu", "snacks_dashboard",
+    function(win) return not vim.api.nvim_win_get_config(win).focusable end,
+  },
   oil   = {
     ".", "..", ".git", ".DS_Store",
     ".venv", ".direnv", ".devenv",

--- a/home/dot_config/nvim/lua/user/flash.lua
+++ b/home/dot_config/nvim/lua/user/flash.lua
@@ -22,15 +22,9 @@ flash.setup({
 })
 
 vim.api.nvim_create_user_command("FlashJumpWord", function(_)
-  require("flash").jump({
-    modes = { char = { jump_labels = true } },
-  })
+  require("flash").jump({ modes = { char = { jump_labels = true } } })
 end, { desc = "Jump to the word", nargs = "*", bang = true })
 
 vim.api.nvim_create_user_command("FlashJumpLine", function(_)
-  require("flash").jump({
-    pattern = "^",
-    search  = { mode = "search" },
-    label   = { after = { 0, 0 } },
-  })
+  require("flash").jump({ pattern = "^", search  = { mode = "search" }, label   = { after = { 0, 0 } } })
 end, { desc = "Jump to the line", nargs = "*", bang = true })


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Add filetype to ignore `flash.nvim`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1211

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
