### PR TITLE
feat(ai): add `chrome-devtools-mcp` as mcp server for global usage

### DIFF
--- a/home/.chezmoitemplates/common/ai/mcp-servers.json.tmpl
+++ b/home/.chezmoitemplates/common/ai/mcp-servers.json.tmpl
@@ -21,6 +21,10 @@
     "args": [ "dlx", "@modelcontextprotocol/server-github@latest" ],
     "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_ACCESS_TOKEN" }
   },
+  "chrome-devtools": {
+    "command": "pnpm",
+    "args": ["dlx", "chrome-devtools-mcp@latest"]
+  },
   "youtube": {
     "command": "pnpm",
     "args": [ "dlx", "@anaisbetts/mcp-youtube" ]


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- add `chrome-devtools-mcp` as mcp server for global usage

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1229

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
