### PR TITLE
feat(neovim): update nvim handlers

### DIFF
--- a/home/dot_config/nvim/lua/core/appearance.lua
+++ b/home/dot_config/nvim/lua/core/appearance.lua
@@ -22,6 +22,9 @@ vim.api.nvim_set_hl(0, "SignColumn",   { ctermbg = 0, bg = palette.bg0 })
 -- Highlight
 vim.g.highlighturl_enabled = true
 
+-- Window
+vim.o.winborder = "rounded"
+
 -- Transparent window
 vim.opt.winblend = 25
 vim.opt.pumblend = 25

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -1,9 +1,1 @@
 -- -*-mode:lua-*- vim:ft=lua
-
-vim.lsp.handlers["textDocument/hover"]         = vim.lsp.with(vim.lsp.buf.hover, { border = "rounded" })
-vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.buf.signature_help, {
-  border = "rounded",
-  silent = true,
-  -- focusable = false,
-  close_events = { "CursorMoved", "CursorMovedI", "BufHidden", "InsertCharPre" },
-})

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -1,1 +1,17 @@
 -- -*-mode:lua-*- vim:ft=lua
+
+-- Supress "No Information Available" notifications
+vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_hover] = function(_, result, _, config)
+  config = config or {}
+  if not (result and result.contents) then
+    return
+  end
+
+  local markdown_lines = vim.lsp.util.convert_input_to_markdown_lines(result.contents)
+  markdown_lines = vim.lsp.util.split(markdown_lines)
+  if vim.tbl_isempty(markdown_lines) then
+    return
+  end
+
+  return vim.lsp.util.open_floating_preview(markdown_lines, "markdown", config)
+end

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -15,3 +15,18 @@ vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_hover] = function(_, resu
 
   return vim.lsp.util.open_floating_preview(markdown_lines, "markdown", config)
 end
+
+
+-- Jump directly to the first available definition every time.
+vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_definition] = function(err, result, ctx, config)
+  if not result or vim.tbl_isempty(result) then
+    vim.notify("[LSP]: Could not find definition\n" .. err, vim.log.levels.INFO)
+    return
+  end
+
+  if vim.tbl_islist(result) then
+    vim.lsp.util.jump_to_location(result[1], "utf-8")
+  else
+    vim.lsp.util.jump_to_location(result, "utf-8")
+  end
+end

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -18,14 +18,14 @@ end
 
 -- Jump directly to the first available definition every time.
 vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_definition] = function(err, result, ctx, _)
+  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
   if err then
-    vim.notify("[LSP]: Definition error" .. err, vim.log.levels.ERROR)
+    vim.notify(string.format("[%s] Definition error: ", client.name, err), vim.log.levels.ERROR)
     return
   end
 
-  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
   if not result or vim.tbl_isempty(result) then
-    vim.notify("[LSP]: Could not find definition: " .. client.name, vim.log.levels.INFO)
+    vim.notify(string.format("[%s]: Could not find definition", client.name), vim.log.levels.INFO)
     return
   end
 
@@ -37,14 +37,14 @@ vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_definition] = function(er
 end
 
 vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_references] = function(err, result, ctx, _)
+  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
   if err then
-    vim.notify("[LSP]: References error: " .. err, vim.log.levels.ERROR)
+    vim.notify(string.format("[%s] Reference error: %s", client.name, err), vim.log.levels.ERROR)
     return
   end
 
-  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
   if not result or vim.tbl_isempty(result) then
-    vim.notify("[LSP]: No references found" .. client.name, vim.log.levels.INFO)
+    vim.notify(string.format("[%s]: No references found", client.name), vim.log.levels.INFO)
     return
   end
 

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -35,3 +35,19 @@ vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_definition] = function(er
     vim.lsp.util.show_document(result, client.offset_encoding, { reuse_win = false, focus = true })
   end
 end
+
+vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_references] = function(err, result, ctx, _)
+  if err then
+    vim.notify("[LSP]: References error: " .. err, vim.log.levels.ERROR)
+    return
+  end
+
+  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+  if not result or vim.tbl_isempty(result) then
+    vim.notify("[LSP]: No references found" .. client.name, vim.log.levels.INFO)
+    return
+  end
+
+  vim.fn.setqflist(vim.lsp.util.locations_to_items(result, "utf-8"))
+  vim.api.nvim_command("copen")
+end

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -16,17 +16,22 @@ vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_hover] = function(_, resu
   return vim.lsp.util.open_floating_preview(markdown_lines, "markdown", config)
 end
 
-
 -- Jump directly to the first available definition every time.
-vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_definition] = function(err, result, ctx, config)
-  if not result or vim.tbl_isempty(result) then
-    vim.notify("[LSP]: Could not find definition\n" .. err, vim.log.levels.INFO)
+vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_definition] = function(err, result, ctx, _)
+  if err then
+    vim.notify("[LSP]: Definition error" .. err, vim.log.levels.ERROR)
     return
   end
 
-  if vim.tbl_islist(result) then
-    vim.lsp.util.jump_to_location(result[1], "utf-8")
+  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+  if not result or vim.tbl_isempty(result) then
+    vim.notify("[LSP]: Could not find definition: " .. client.name, vim.log.levels.INFO)
+    return
+  end
+
+  if vim.islist(result) then
+    vim.lsp.util.show_document(result[1], client.offset_encoding, { reuse_win = false, focus = true })
   else
-    vim.lsp.util.jump_to_location(result, "utf-8")
+    vim.lsp.util.show_document(result, client.offset_encoding, { reuse_win = false, focus = true })
   end
 end

--- a/home/dot_config/nvim/lua/lsp/config/handlers.lua
+++ b/home/dot_config/nvim/lua/lsp/config/handlers.lua
@@ -51,3 +51,11 @@ vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_references] = function(er
   vim.fn.setqflist(vim.lsp.util.locations_to_items(result, "utf-8"))
   vim.api.nvim_command("copen")
 end
+
+vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_codeAction] = function(_, _, actions)
+  if not actions or vim.tbl_isempty(actions) then
+    return
+  end
+
+  vim.lsp.util.show_code_actions(actions)
+end


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Remove deprecated: `vim.lsp.with`
- Add `vim.o.winborder` option
- Add custom handlers
  - `textDocument/hover`
  - `textDocument/definition`
  - `textDocument/references`
  - `textDocument/implementation`
  - `textDocument/codeAction`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1237

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
