### PR TITLE
feat(neovim): update nvim keymap

### DIFF
--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -17,14 +17,12 @@ local ok, wk = pcall(require, "which-key")
 if not ok then vim.notify("Failed loading " .. "which-key", vim.log.levels.WARN) end
 
 -- Abbreviation for typo
-vim.cmd[[
-  cnoreabbrev Q! q!
-  cnoreabbrev q1 q!
-  cnoreabbrev Q1 q!
-  cnoreabbrev W! w!
-  cnoreabbrev Wq wq
-  cnoreabbrev WQ wq
-]]
+vim.cmd.cnoreabbrev("Q!", "q!")
+vim.cmd.cnoreabbrev("q1", "q!")
+vim.cmd.cnoreabbrev("Q1", "q!")
+vim.cmd.cnoreabbrev("W!", "w!")
+vim.cmd.cnoreabbrev("Wq", "wq")
+vim.cmd.cnoreabbrev("WQ", "wq")
 
 ---------------------------------------------------------------------------
 -- which-key: <Leader> + w

--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -11,7 +11,6 @@ return {
 
   {
     "folke/which-key.nvim", -- Shortcut / Keymap
-    cond   = not vim.g.vscode,
     event  = "VeryLazy",
     config = function()
       require("user.which-key")


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Refine abbreviation keymap for command line mode
- Remove condition to load `which-key.nvim`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1239

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
