### PR TITLE
feat(neovim): update nvim keymaps

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -87,18 +87,14 @@ local lsp_group = augroup("LspCustomGroup")
 vim.api.nvim_create_autocmd({ "LspAttach" }, {
   group    = lsp_group,
   callback = function(ev)
-    require("which-key").add({
-      mode    = "n",
-      noremap = true,
-      silent  = true,
-      { "K",  vim.lsp.buf.hover,          buffer = ev.buf, icon = "󰈙 ", desc = "Hover Docs" },
-      { "gd", vim.lsp.buf.definition,     buffer = ev.buf, icon = "󰫧 ", desc = "Definition" },
-      { "gD", vim.lsp.buf.declaration,    buffer = ev.buf, icon = " ", desc = "Declaration" },
-      { "gI", vim.lsp.buf.implementation, buffer = ev.buf, icon = " ", desc = "Implementation" },
-      { "gr", vim.lsp.buf.rename,         buffer = ev.buf, icon = "󰑕 ", desc = "Rename" },
-      { "gR", vim.lsp.buf.references,     buffer = ev.buf, icon = " ", desc = "References" },
-      { "ga", vim.lsp.buf.code_action,    buffer = ev.buf, icon = " ", desc = "Code Action" },
-    })
+    local extend, opts = vim.tbl_extend, { buffer = ev.buf, noremap = true, silent = true }
+    vim.keymap.set("n", "K",          vim.lsp.buf.hover,          extend("keep", opts, { desc = "Hover Docs" }))
+    vim.keymap.set("n", "gd",         vim.lsp.buf.definition,     extend("keep", opts, { desc = "Definition" }))
+    vim.keymap.set("n", "gD",         vim.lsp.buf.declaration,    extend("keep", opts, { desc = "Declaration" }))
+    vim.keymap.set("n", "gri",        vim.lsp.buf.implementation, extend("keep", opts, { desc = "Implementation" }))
+    vim.keymap.set("n", "grn",        vim.lsp.buf.rename,         extend("keep", opts, { desc = "Rename" }))
+    vim.keymap.set("n", "grf",        vim.lsp.buf.references,     extend("keep", opts, { desc = "References" }))
+    vim.keymap.set({"n", "v"}, "gra", vim.lsp.buf.code_action,    extend("keep", opts, { desc = "Code Action" }))
   end
 })
 

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -232,7 +232,13 @@ if not is_vscode then
       "<Leader>fL",
       "<CMD>lua Snacks.picker.smart({cwd = vim.fn.stdpath('data') .. '/lazy'})<CR>",
       icon = " ",
-      desc = "nvim plugins",
+      desc = "Find nvim plugin files",
+    },
+    {
+      "<Leader>fG",
+      "<CMD>lua Snacks.picker.grep({cwd = vim.fn.stdpath('data') .. '/lazy'})<CR>",
+      icon = " ",
+      desc = "Grep search in nvim plugin files",
     },
     {
       "<Leader>ft",

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -203,6 +203,7 @@ if not is_vscode then
     -- Grep
     { "<C-g>",      "<CMD>lua Snacks.picker.grep({ live = true })<CR>",  icon = " ", desc = "Live Grep" },
     { "<Leader>fw", "<CMD>lua Snacks.picker.grep_word()<CR>", mode = nx, icon = " ", desc = "grep with cword" },
+    { "<Leader>/",  "<CMD>lua Snacks.picker.lines()<CR>",                icon = "󰘤 ", desc = "Grep current buffer" },
 
     -- Vim
     { "<Leader>fh", "<CMD>lua Snacks.picker.help()<CR>",       icon = " ", desc = "Help" },

--- a/home/dot_config/nvim/lua/user/treesitter/comment.lua
+++ b/home/dot_config/nvim/lua/user/treesitter/comment.lua
@@ -17,3 +17,12 @@ comment.setup({
   pre_hook  = require('ts_context_commentstring.integrations.comment_nvim').create_pre_hook(),
   post_hook = function() end,
 })
+
+-- Workaround overlapping with `gb` & `gc`: numToStr/Comment.nvim#483
+vim.keymap.del("n", "gb")
+vim.keymap.del("n", "gc")
+
+require("which-key").add({
+  { "gb", group = "Toggle comment blockwise", icon = " " },
+  { "gc", group = "Toggle comment linewise",  icon = " " },
+})


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Add keymap to search current buffer with `grep` using `snacks.picker.lines()`
- Add keymap to search nvim plugins with `grep` using `snacks.picker.smart()`
- Update LSP related keymaps: to prevent overlapping warning on `checkhealth which-key`
- Add comment-related keymap config to workaround overlapping warning on `checkhealth`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1251

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
