### PR TITLE
feat(neovim): refactor env variables

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -69,7 +69,7 @@ vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost", "InsertEnter", "CmdlineEn
 
 -- Surveillance chezmoi target files
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
-  pattern  = { os.getenv("HOME") .. "/.local/share/chezmoi/*" },
+  pattern  = { vim.env.HOME .. "/.local/share/chezmoi/*" },
   callback = function() vim.schedule(require("chezmoi.commands.__edit").watch) end,
 })
 

--- a/home/dot_config/nvim/lua/debugger/config/javascript.lua
+++ b/home/dot_config/nvim/lua/debugger/config/javascript.lua
@@ -2,7 +2,7 @@
 local util = require("utils.javascript")
 -- local cwd  = vim.fs.root(0, "package.json") or vim.fn.getcwd()
 local npm  = vim.fn.executable("pnpm") and "pnpm " or "npm "
-local braveExe = os.getenv("HOME") .. "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+local braveExe = vim.env.HOME .. "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
 
 local configs = {
   {

--- a/home/dot_config/nvim/lua/debugger/config/python.lua
+++ b/home/dot_config/nvim/lua/debugger/config/python.lua
@@ -1,5 +1,5 @@
 -- -*-mode:lua-*- vim:ft=lua
-local venv = os.getenv('VIRTUAL_ENV')
+local venv = vim.env.VIRTUAL_ENV
 local pkg = "debugpy"
 
 return {

--- a/home/dot_config/nvim/lua/lsp/cmp/luasnip.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/luasnip.lua
@@ -161,7 +161,7 @@ end, { desc = "Reload luasnip snippets", nargs = "*", bang = true })
 
 vim.api.nvim_create_user_command("LuaSnipEdit", function()
   -- require("luasnip.loaders").edit_snippet_files({})
-  require("snacks.picker").smart({ cwd = os.getenv("XDG_DATA_HOME") .. "/chezmoi/home/dot_config/nvim/lua/snippets" })
+  require("snacks.picker").smart({ cwd = vim.env.XDG_DATA_HOME .. "/chezmoi/home/dot_config/nvim/lua/snippets" })
 end, { desc = "", nargs = "*", bang = true })
 
 vim.api.nvim_create_user_command("LuaSnipBrowse", function()

--- a/home/dot_config/nvim/lua/lsp/servers/gopls.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/gopls.lua
@@ -47,7 +47,7 @@ return {
         unusedwrite  = true,
         useany       = true,
       },
-      buildFlags = { os.getenv("GOFLAGS") }
+      buildFlags = { vim.env.GOFLAGS }
     },
   },
   autostart = true,


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Replace `os.getenv` to `vim.env.*`
  - `HOME`
  - `XDG_DATA_HOME`
  - `VIRTUAL_ENV`
  - `GOFLAGS`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1259

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
