### PR TITLE
revert(zellij): restore the zellij config to not use programmatic code in `.chezmoiexternals`

### DIFF
--- a/home/.chezmoidata/zellij.toml
+++ b/home/.chezmoidata/zellij.toml
@@ -28,19 +28,3 @@ bg = "green"
 
 [zellij.tab.active]
 fg = "green"
-
-[[zellij.plugins]]
-repo = "imsnif/multitask"
-file = "multitask.wasm"
-
-[[zellij.plugins]]
-repo = "fresh2dev/zellij-autolock"
-file = "zellij-autolock.wasm"
-
-[[zellij.plugins]]
-repo = "dj95/zjstatus"
-file = "zjstatus.wasm"
-
-[[zellij.plugins]]
-repo = "dj95/zjstatus"
-file = "zjframes.wasm"

--- a/home/.chezmoiexternals/zellij.toml.tmpl
+++ b/home/.chezmoiexternals/zellij.toml.tmpl
@@ -6,8 +6,18 @@ stripComponents = 1
 refreshPeriod = "672h"
 {{- end }}
 
-{{- range $plugin := .zellij.plugins }}
-[".local/share/zellij/plugins/{{ $plugin.file }}"]
+[".local/share/zellij/plugins/multitask.wasm"]
 {{ template "file" }}
-url = {{ gitHubLatestReleaseAssetURL $plugin.repo $plugin.file | quote }}
-{{- end }}
+url = {{ gitHubLatestReleaseAssetURL "imsnif/multitask" "multitask.wasm" | quote }}
+
+[".local/share/zellij/plugins/zellij-autolock.wasm"]
+{{ template "file" }}
+url = {{ gitHubLatestReleaseAssetURL "fresh2dev/zellij-autolock" "zellij-autolock.wasm" | quote }}
+
+[".local/share/zellij/plugins/zjstatus.wasm"]
+{{ template "file" }}
+url = {{ gitHubLatestReleaseAssetURL "dj95/zjstatus" "zjstatus.wasm" | quote }}
+
+[".local/share/zellij/plugins/zjframes.wasm"]
+{{ template "file" }}
+url = {{ gitHubLatestReleaseAssetURL "dj95/zjstatus" "zjframes.wasm" | quote }}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- programmatic code cause slow down while `chezmoi apply` is running

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1273

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
