### PR TITLE
feat(neovim): update nvim completion config

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Other Homebrew packages: [**`Brewfile`**](https://github.com/MasahiroSakoda/dotf
 
 * [Builtin LSP Supported](#lsp)
 * [DAP supported](#dap) with [**`nvim-dap`**](https://github.com/mfussenegger/nvim-dap), [**`nvim-dap-ui`**](https://github.com/rcarriga/nvim-dap-ui)
+* Addtional completion with [blink.cmp](https://github.com/saghen/blink.cmp)
 * [Linter support](#linter)
 * [Formatter support](#formatter)
 * Snippet support: [**`LuaSnip`**](https://github.com/L3MON4D3/LuaSnip), [**`friendly-snippets`**](https://github.com/rafamadriz/friendly-snippets)

--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -118,17 +118,9 @@ vim.api.nvim_create_autocmd({ "LspAttach" }, {
   callback = function(ev)
     local client = assert(vim.lsp.get_client_by_id(ev.data.client_id))
     if client:supports_method(vim.lsp.protocol.Methods.textDocument_completion, ev.buf) then
+      --Enable completion triggered by <c-x><c-o>
       vim.bo[ev.buf].omnifunc = "v:lua.vim.lsp.omnifunc"
-
-      local kinds_ok, kinds = pcall(require, "lspkind")
-      vim.lsp.completion.enable(true, client.id, ev.buf, {
-        autotrigger = true,
-        convert = function(item)
-          local kind = vim.lsp.protocol.CompletionItemKind[item.kind] or "Unknown"
-          local icon = kinds_ok and string.format("%s", kinds.presets.default[kind]) or kind
-          return { abbr = icon .. " " .. item.label, kind = kind, menu = item.detail or "", icase = 1 }
-        end
-      })
+      vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
     end
   end
 })

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -40,7 +40,7 @@ blink.setup({
   signature = { enabled = true }, -- Experimental option
 
   sources = {
-    default = { "lsp", "path", "buffer", "snippets", "markdown" },
+    default = { "lsp", "omni", "path", "buffer", "snippets", "markdown" },
 
     per_filetype = {
       lua      = { inherit_defaults = true, "lazydev" },

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -47,12 +47,6 @@ blink.setup({
       markdown = { "lsp", "snippets", "path", "buffer", "markdown" },
     },
     providers = {
-      lsp      = { min_keyword_length = function(ctx) return ctx.trigger.kind == "manual" and 0 or 2  end },
-      path     = { min_keyword_length = 0 },
-      buffer   = { min_keyword_length = 5 },
-      snippets = { min_keyword_length = 1 },
-
-      -- Third party plugin integration
       lazydev  = { name = "LazyDev",        module = "lazydev.integrations.blink",  score_offset = 100 },
       markdown = { name = 'RenderMarkdown', module = "render-markdown.integ.blink", score_offset = 20 },
     },

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -40,10 +40,11 @@ blink.setup({
   signature = { enabled = true }, -- Experimental option
 
   sources = {
-    default = { "lsp", "omni", "path", "buffer", "snippets", "markdown" },
+    default = { "lsp", "path", "buffer", "snippets" },
 
     per_filetype = {
       lua      = { inherit_defaults = true, "lazydev" },
+      markdown = { inherit_defaults = true, "markdown" },
     },
     providers = {
       lsp      = { min_keyword_length = function(ctx) return ctx.trigger.kind == "manual" and 0 or 2  end },

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -52,8 +52,8 @@ blink.setup({
       snippets = { min_keyword_length = 1 },
 
       -- Third party plugin integration
-      lazydev       = { name = "LazyDev",        module = "lazydev.integrations.blink",  fallbacks = { "lazy_dev" } },
-      markdown      = { name = 'RenderMarkdown', module = 'render-markdown.integ.blink', fallbacks = { 'lsp' } },
+      lazydev  = { name = "LazyDev",        module = "lazydev.integrations.blink",  score_offset = 100 },
+      markdown = { name = 'RenderMarkdown', module = "render-markdown.integ.blink", score_offset = 20 },
     },
   },
 

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -34,7 +34,7 @@ blink.setup({
   appearance = {
     use_nvim_cmp_as_default = false,
     nerd_font_variant = "mono", ---@type "mono"|"normal"
-    kind_icons = require("lspkind").presets,
+    kind_icons = require("lspkind").presets.default,
   },
 
   signature = { enabled = true }, -- Experimental option
@@ -125,11 +125,7 @@ blink.setup({
       end,
       border = {"┏", "━", "┓", "┃", "┛", "━", "┗", "┃"},
       draw = {
-        columns = {
-          { "kind_icon", gap = 1 },
-          { "label", "label_description", gap = 1 },
-          { "source_name" },
-        },
+        columns = { { "kind_icon" }, { "label", "label_description", gap = 1 }, { "source_name" } },
         treesitter = { "lsp" },
       },
     },

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -43,8 +43,8 @@ blink.setup({
     default = { "lsp", "path", "buffer", "snippets" },
 
     per_filetype = {
-      lua      = { inherit_defaults = true, "lazydev" },
-      markdown = { inherit_defaults = true, "markdown" },
+      lua      = { "lazydev", "lsp", "snippets", "path", "buffer" },
+      markdown = { "lsp", "snippets", "path", "buffer", "markdown" },
     },
     providers = {
       lsp      = { min_keyword_length = function(ctx) return ctx.trigger.kind == "manual" and 0 or 2  end },

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -58,6 +58,8 @@ blink.setup({
     },
   },
 
+  fuzzy = { implementation = "prefer_rust_with_warning" },
+
   ---@see https://cmp.saghen.dev/modes/cmdline.html
   cmdline = {
     enabled = true,

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -127,6 +127,29 @@ blink.setup({
       draw = {
         columns = { { "kind_icon" }, { "label", "label_description", gap = 1 }, { "source_name" } },
         treesitter = { "lsp" },
+        components = {
+          kind_icon = {
+            text = function(ctx)
+              local icon = ctx.kind_icon
+              if vim.tbl_contains({ "Path" }, ctx.source_name) then
+                local dev_icon, _ = require("nvim-web-devicons").get_icon(ctx.label)
+                if dev_icon then icon = dev_icon end
+              else
+                icon = require("lspkind").symbolic(ctx.kind, { mode = "symbol" })
+              end
+              return icon .. ctx.icon_gap
+            end,
+
+            highlight = function(ctx)
+              local hl = ctx.kind_hl
+              if vim.tbl_contains({ "Path" }, ctx.source_name) then
+                local dev_icon, dev_hl = require("nvim-web-devicons").get_icon(ctx.label)
+                if dev_icon then hl = dev_hl end
+              end
+              return hl
+            end,
+          }
+        }
       },
     },
   },

--- a/home/dot_config/nvim/lua/plugins/cmp.lua
+++ b/home/dot_config/nvim/lua/plugins/cmp.lua
@@ -61,11 +61,10 @@ return {
   {
     "saghen/blink.cmp",
     version = "1.*",
-    dependencies = {
-      "onsails/lspkind.nvim",
-    },
-    cond   = not vim.g.vscode,
-    event  = { "InsertEnter" },
-    config = function() require("lsp.cmp.blink") end,
+    dependencies = { "onsails/lspkind.nvim" },
+    cond         = not vim.g.vscode,
+    event        = { "InsertEnter", "CmdlineEnter" },
+    opts_extend  = { "sources.default", "sources.completion.enabled_providers" },
+    config       = function() require("lsp.cmp.blink") end,
   },
 }


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Update `blink.cmp` source config
- Update `vim.lsp.completion` option for icon config
- Update compleiton menu integrated with `nvim-web-devicons` & `lspkind`
- Add fuzzy matcher config
- Update completion sources for specific filetypes
- Update sorting priority with `score_offset`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1287

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
