### PR TITLE
feat(neovim): update oilnvim config

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -170,11 +170,3 @@ vim.api.nvim_create_autocmd({ "ModeChanged" }, {
     end
   end,
 })
-
--- Workaround oil.nvim relative path issue
--- https://github.com/stevearc/oil.nvim/issues/234
-vim.api.nvim_create_autocmd({ "BufLeave" }, {
-  group    = augroup("OilRelativePathFix"),
-  pattern  = "oil:///*",
-  callback = function() vim.cmd("cd .") end,
-})

--- a/home/dot_config/nvim/lua/ui/oil.lua
+++ b/home/dot_config/nvim/lua/ui/oil.lua
@@ -42,6 +42,8 @@ oil.setup({
     ["<CR>"]  =   "actions.select",
     ["<C-l>"] =   "actions.refresh",
     ["<C-p>"] =   "actions.preview",
+    ["<C-u>"] =   "actions.preview_scroll_up",
+    ["<C-d>"] =   "actions.preview_scroll_down",
     ["<C-s>"] = { "actions.select", opts = { vertical = true } },
     ["<C-h>"] = { "actions.select", opts = { horizontal = true } },
     ["<C-t>"] = { "actions.select", opts = { tab = true } },


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Remove unused autocmd for `oil.nvim`
- Add keymap to scroll preview

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1425

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
