### PR TITLE
feat(neovim): update nvim keymaps

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -53,8 +53,8 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
     -- Defer to ensure overriding default keymaps
     vim.schedule(function()
       require("which-key").add({
-        { "<ESC>", "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
         { "jj",    "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
+        { "kk",    "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
       })
     end)
   end,

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -363,6 +363,7 @@ wk.add({
   { "<Leader>gg",  "<CMD>lua Snacks.terminal('gitui')<CR>",    mode = nt, icon = " ", desc = " Toggle GitUI" },
   { "<Leader>gt",  "<CMD>lua Snacks.terminal('tig')<CR>",      mode = nt, icon = " ", desc = " Toggle tig" },
   { "<Leader>ghd", "<CMD>lua Snacks.terminal('gh dash')<CR>",  mode = nt, icon = " ", desc = " Toggle gh-dash" },
+  { "<Leader>ghg", "<CMD>lua Snacks.terminal('gh graph')<CR>", mode = nt, icon = " ", desc = " Toggle gh graph" },
 }, opts)
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -362,6 +362,7 @@ wk.add({
 
   { "<Leader>gg",  "<CMD>lua Snacks.terminal('gitui')<CR>",    mode = nt, icon = " ", desc = " Toggle GitUI" },
   { "<Leader>gt",  "<CMD>lua Snacks.terminal('tig')<CR>",      mode = nt, icon = " ", desc = " Toggle tig" },
+  { "<Leader>ghd", "<CMD>lua Snacks.terminal('gh dash')<CR>",  mode = nt, icon = " ", desc = " Toggle gh-dash" },
 }, opts)
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -360,7 +360,7 @@ wk.add({
   { "[g", "<CMD>Gitsigns nav_hunk prev<CR>", icon = " ", desc = " Jump to prev hunk" },
   { "]g", "<CMD>Gitsigns nav_hunk next<CR>", icon = " ", desc = " Jump to next hunk" },
 
-  { "<Leader>gg", "<CMD>lua Snacks.lazygit()<CR>", mode = nt, icon = " ", desc = " Toggle lazygit" },
+  { "<Leader>gg",  "<CMD>lua Snacks.terminal('gitui')<CR>",   mode = nt, icon = " ", desc = " Toggle GitUI" },
 }, opts)
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -360,7 +360,8 @@ wk.add({
   { "[g", "<CMD>Gitsigns nav_hunk prev<CR>", icon = " ", desc = " Jump to prev hunk" },
   { "]g", "<CMD>Gitsigns nav_hunk next<CR>", icon = " ", desc = " Jump to next hunk" },
 
-  { "<Leader>gg",  "<CMD>lua Snacks.terminal('gitui')<CR>",   mode = nt, icon = " ", desc = " Toggle GitUI" },
+  { "<Leader>gg",  "<CMD>lua Snacks.terminal('gitui')<CR>",    mode = nt, icon = " ", desc = " Toggle GitUI" },
+  { "<Leader>gt",  "<CMD>lua Snacks.terminal('tig')<CR>",      mode = nt, icon = " ", desc = " Toggle tig" },
 }, opts)
 
 ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Replace `lazygit` keymap to `gitui`
- Add `Snacks.terminal` keymap for `tig`
- Add `Snacks.terminal` keymap for `gh dash`
- Replace `<ESC>` keymap in terminal mode: which is conflict with tui

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1453

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
