### PR TITLE
feat(neovim): update snacks.nvim configs

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -48,13 +48,13 @@ vim.api.nvim_create_autocmd("FileType", {
 -- Terminal buffer keymap
 vim.api.nvim_create_autocmd({ "FileType" }, {
   group    = vim.api.nvim_create_augroup("TerminalCustomGroup", { clear = true }),
-  pattern  = { "terminal", "snacks_terminal", "sidekick_terminal" },
+  pattern  = { "sidekick_terminal" },
   callback = function(ev)
     -- Defer to ensure overriding default keymaps
     vim.schedule(function()
       require("which-key").add({
-        { "jj",    "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
-        { "kk",    "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
+        { "jj", "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
+        { "kk", "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
       })
     end)
   end,

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -362,6 +362,13 @@ wk.add({
   { "<Leader>gg",  "<CMD>lua Snacks.terminal('gitui')<CR>",   mode = nt, icon = " ", desc = " Toggle GitUI" },
   { "<Leader>gt",  "<CMD>lua Snacks.terminal('tig')<CR>",     mode = nt, icon = " ", desc = " Toggle tig" },
   { "<Leader>ghd", "<CMD>lua Snacks.terminal('gh dash')<CR>", mode = nt, icon = " ", desc = " Toggle gh-dash" },
+  {
+    "<Leader>gC",
+    "<CMD>lua Snacks.terminal('git status --verbose; cz')<CR>",
+    mode = nt,
+    icon = " ",
+    desc = " Commitizen",
+  },
 }, opts)
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -359,10 +359,9 @@ wk.add({
   { "[g", "<CMD>Gitsigns nav_hunk prev<CR>", icon = " ", desc = " Jump to prev hunk" },
   { "]g", "<CMD>Gitsigns nav_hunk next<CR>", icon = " ", desc = " Jump to next hunk" },
 
-  { "<Leader>gg",  "<CMD>lua Snacks.terminal('gitui')<CR>",    mode = nt, icon = " ", desc = " Toggle GitUI" },
-  { "<Leader>gt",  "<CMD>lua Snacks.terminal('tig')<CR>",      mode = nt, icon = " ", desc = " Toggle tig" },
-  { "<Leader>ghd", "<CMD>lua Snacks.terminal('gh dash')<CR>",  mode = nt, icon = " ", desc = " Toggle gh-dash" },
-  { "<Leader>ghg", "<CMD>lua Snacks.terminal('gh graph')<CR>", mode = nt, icon = " ", desc = " Toggle gh graph" },
+  { "<Leader>gg",  "<CMD>lua Snacks.terminal('gitui')<CR>",   mode = nt, icon = " ", desc = " Toggle GitUI" },
+  { "<Leader>gt",  "<CMD>lua Snacks.terminal('tig')<CR>",     mode = nt, icon = " ", desc = " Toggle tig" },
+  { "<Leader>ghd", "<CMD>lua Snacks.terminal('gh dash')<CR>", mode = nt, icon = " ", desc = " Toggle gh-dash" },
 }, opts)
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -240,8 +240,7 @@ if not is_vscode then
     { "<Leader>gs", "<CMD>lua Snacks.picker.git_status()<CR>",            icon = " ", desc = " Git Status" },
     { "<Leader>gS", "<CMD>lua Snacks.picker.git_stash()<CR>",             icon = " ", desc = " Git Stash" },
     { "<Leader>gl", "<CMD>lua Snacks.picker.git_log()<CR>",               icon = " ", desc = " Commit Log" },
-    { "<Leader>gd", "<CMD>lua Snacks.picker.git_diff()<CR>",              icon = " ", desc = " Diff (origin)" },
-    { "<Leader>gD", "<CMD>lua Snacks.picker.git_diff({staged=true})<CR>", icon = " ", desc = " Diff (staged)" },
+    { "<Leader>gd", "<CMD>lua Snacks.picker.git_diff({staged=true})<CR>", icon = " ", desc = " Diff (staged)" },
     { "<Leader>gb", "<CMD>lua Snacks.picker.git_branches()<CR>",          icon = " ", desc = " View branches" },
 
     -- GitHub

--- a/home/dot_config/nvim/lua/user/snacks/picker/git_diff.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/git_diff.lua
@@ -1,0 +1,22 @@
+-- -*-mode:lua-*- vim:ft=lua
+
+---@type snacks.picker.Config
+return {
+  focus = "list",
+  win = {
+    input = {
+      ["<Tab>"] = { "select_and_next", mode = { "n", "i" } },
+      ["f"]     = { "focus_list",      mode = { "n" } },
+      ["2"]     = { "focus_list",      mode = { "n" } },
+      ["3"]     = { "focus_preview",   mode = { "n" } },
+    },
+    list = {
+      keys = {
+        ["e"]       = { "edit" },
+        ["s"]       = { "git_stage" },
+        ["<Space>"] = { "git_stage" },
+        ["<Tab>"]   = { "select_and_next" },
+      },
+    },
+  },
+}

--- a/home/dot_config/nvim/lua/user/snacks/picker/git_status.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/git_status.lua
@@ -1,0 +1,22 @@
+-- -*-mode:lua-*- vim:ft=lua
+
+---@type snacks.picker.Config
+return {
+  focus = "list",
+  win = {
+    input = {
+      ["<Tab>"] = { "select_and_next", mode = { "n", "i" } },
+      ["f"]     = { "focus_list",      mode = { "n" } },
+      ["2"]     = { "focus_list",      mode = { "n" } },
+      ["3"]     = { "focus_preview",   mode = { "n" } },
+    },
+    list = {
+      keys = {
+        ["e"]       = { "edit" },
+        ["s"]       = { "git_stage" },
+        ["<Space>"] = { "git_stage" },
+        ["<Tab>"]   = { "select_and_next" },
+      },
+    },
+  },
+}

--- a/home/dot_config/nvim/lua/user/snacks/picker/init.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/init.lua
@@ -34,9 +34,11 @@ return {
     files = { hidden = true },
     smart = { hidden = true, filter = { cwd = true } },
     grep  = { hidden = true },
-    snippets = require("user.snacks.picker.snippets"),
-    gh_issue = {},
-    gh_pr = {},
+    snippets   = require("user.snacks.picker.snippets"),
+    git_status = require("user.snacks.picker.git_status"),
+    git_diff   = require("user.snacks.picker.git_diff"),
+    gh_issue   = {},
+    gh_pr      = {},
   },
 
   win = {


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- Configure `Snacks.picker` keymaps related `git`
  - `git_status`
  - `git_diff`
- Disable Esc key in terminal mode: only `sidekick_terminal` to scroll in tui
- Remove unused `Snacks.picker` diff keymap: which leave it to `Snacks.picker.status()`
- Remove meaningless keymap: `gh graph`
- Add `Snacks.terminal` keymap for `commitizen`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1461

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
