### PR TITLE
feat(neovim): update plugin loading timing via `lazy.nvim`

### DIFF
--- a/home/dot_config/nvim/lua/plugins/appearance.lua
+++ b/home/dot_config/nvim/lua/plugins/appearance.lua
@@ -21,7 +21,7 @@ return {
     "akinsho/bufferline.nvim", -- Tab page integration
     dependencies = { "nvim-tree/nvim-web-devicons" },
     cond   = not vim.g.vscode,
-    event  = { "VeryLazy" },
+    event  = { "BufReadPost", "BufNewFile" },
     config = function() require("ui.bufferline") end,
   },
   {

--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -27,7 +27,7 @@ return {
   {
     "folke/flash.nvim",
     cond   = not vim.g.vscode,
-    event  = "VeryLazy",
+    event  = { "BufReadPost", "BufNewFile" },
     init   = function() require("ui.flash") end,
     config = function() require("user.flash") end,
   },
@@ -44,7 +44,7 @@ return {
   {
     "kylechui/nvim-surround",
     version = "^3.0.0",
-    event   = "VeryLazy",
+    event   = { "BufReadPost", "BufNewFile" },
     config  = function() require("user.surround") end,
   },
   -- Quickfix

--- a/home/dot_config/nvim/lua/plugins/treesitter.lua
+++ b/home/dot_config/nvim/lua/plugins/treesitter.lua
@@ -32,7 +32,7 @@ return {
   { "andymass/vim-matchup",   ft = ft.matchup, config = function() require("user.treesitter.matchup") end },
   {
     "numToStr/Comment.nvim",
-    event  = { "VeryLazy" },
+    event  = { "BufReadPost", "BufNewFile" },
     config = function() require("user.treesitter.comment") end,
   },
   {


### PR DESCRIPTION

# Summary
<!-- add the description of the PR here -->

- Update plugin loading timing via `lazy.nvim`
  - `bufferline.nvim`: `VeryLazy` -> `BufReadPost`, `BufNewFile`
  - `Comment.nvim`: `VeryLazy` -> `BufReadPost`, `BufNewFile`
  - `flash.nvim`: `VeryLazy` -> `BufReadPost`, `BufNewFile`
  - `nvim-surround`: `VeryLazy` -> `BufReadPost`, `BufNewFile`

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1463

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
