### PR TITLE
feat(nvim): update sidekicknvim config

### DIFF
--- a/home/dot_config/nvim/lua/ai/sidekick/init.lua
+++ b/home/dot_config/nvim/lua/ai/sidekick/init.lua
@@ -7,9 +7,8 @@ vim.g.sidekick_nes = false
 ---@class sidekick.Config
 sidekick.setup({
   nes = {
-    enabled = function(_)
-      return vim.g.sidekick_nes ~= false and vim.b.sidekick_nes ~= false
-    end,
+    -- TODO: Enable inline completion when NeoVim 0.12.x stable releases
+    enabled = false,
     debounce = 500,
   },
   cli = {

--- a/home/dot_config/nvim/lua/ai/sidekick/init.lua
+++ b/home/dot_config/nvim/lua/ai/sidekick/init.lua
@@ -54,7 +54,7 @@ sidekick.setup({
 
   ---@class sidekick.cli.Mux
   mux = {
-    backend = vim.env.ZELLIJ and "zellij" or "tmux", -- default to tmux unless zellij is detected
+    backend = "zellij",
     enabled = true,
   },
 })

--- a/home/dot_config/nvim/lua/ai/sidekick/init.lua
+++ b/home/dot_config/nvim/lua/ai/sidekick/init.lua
@@ -22,14 +22,14 @@ sidekick.setup({
 
       ---@type table<string, sidekick.cli.Keymap|false>
       keys = {
-        buffers       = { "<c-b>", "buffers"   , mode = "nt", desc = "open buffer picker" },
-        files         = { "<c-f>", "files"     , mode = "nt", desc = "open file picker" },
-        hide_n        = { "q"    , "hide"      , mode = "n" , desc = "hide the terminal window" },
-        hide_ctrl_q   = { "<c-q>", "hide"      , mode = "n" , desc = "hide the terminal window" },
-        hide_ctrl_dot = { "<c-.>", "hide"      , mode = "nt", desc = "hide the terminal window" },
-        hide_ctrl_z   = { "<c-z>", "hide"      , mode = "nt", desc = "hide the terminal window" },
-        prompt        = { "<c-,>", "prompt"    , mode = "t" , desc = "insert prompt or context" },
-        stopinsert    = { "<c-q>", "stopinsert", mode = "t" , desc = "enter normal mode" },
+        buffers       = { "<c-\\>", "buffers"   , mode = "nt", desc = "open buffer picker" },
+        files         = { "<c-'>",  "files"     , mode = "nt", desc = "open file picker" },
+        hide_n        = { "q"    ,  "hide"      , mode = "n" , desc = "hide the terminal window" },
+        hide_ctrl_q   = { "<c-q>",  "hide"      , mode = "n" , desc = "hide the terminal window" },
+        hide_ctrl_dot = { "<c-.>",  "hide"      , mode = "nt", desc = "hide the terminal window" },
+        hide_ctrl_z   = { "<c-z>",  "hide"      , mode = "nt", desc = "hide the terminal window" },
+        prompt        = { "<c-,>",  "prompt"    , mode = "t" , desc = "insert prompt or context" },
+        stopinsert    = { "<c-q>",  "stopinsert", mode = "t" , desc = "enter normal mode" },
         -- Navigate windows in terminal mode. Only active when:
         -- * layout is not "float"
         -- * there is another window in the direction


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

- [0e80f7ae](https://github.com/MasahiroSakoda/dotfiles/commit/0e80f7ae) feat(nvim): update sidekick keymaps to avoid conflict with defaults
- [bd4c0ef7](https://github.com/MasahiroSakoda/dotfiles/commit/bd4c0ef7) chore(nvim): disable sidekick inline completion
- [5cef3c16](https://github.com/MasahiroSakoda/dotfiles/commit/5cef3c16) feat(nvim): force zellij as sidekick mux backend

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1487

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
