### PR TITLE
feat(opencode): add missing git commit command template

### DIFF
--- a/home/dot_config/opencode/command/git/commit.md.tmpl
+++ b/home/dot_config/opencode/command/git/commit.md.tmpl
@@ -1,0 +1,15 @@
+---
+name: commit
+description: Generate conventional commit message from staged changes.
+agent: planner
+---
+
+# Conventional Commit Generator
+
+You are an AI assistant programmed to perform meticulous, context-aware commit message generations using the tools available in the OpenCode.
+Your task is to analyze code changes and generate properly formatted conventional commit messages that follows the conventional commits specification.
+
+{{ includeTemplate "common/ai/commands/git/commit.md" . }}
+{{- /*<!--
+mode:markdown vim:ft=markdown.gotexttmpl
+-->*/ -}}


### PR DESCRIPTION
• Add `commit.md.tmpl` to OpenCode command configuration • Integrate conventional commit generator with shared template • Restore missing functionality for generating commit messages

# Summary
<!-- add the description of the PR here -->

- add missing git commit command template

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1489

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
