### PR TITLE
feat(nvim): Update snippet config

### DIFF
--- a/home/dot_config/nvim/lua/snippets/lua.lua
+++ b/home/dot_config/nvim/lua/snippets/lua.lua
@@ -247,25 +247,22 @@ local snippets = {
     ]], { i(1, "module"), rep(1), rep(1), i(0) })
   ),
 
-  s({ trig = "wkeygrp", name = "Keymap Group",  dscr = "Keymap Group for which-key.nvim" },
+  s({ trig = "wkg", name = "Keymap Group",  dscr = "Keymap Group for which-key.nvim" },
     fmta('{ "<lhs>", group = "<grp>", icon = "<icon> " },', {
-      lhs  = c(1, {
-        sn(1, { t("<Leader>"), r(1, "lhs") }),
-        sn(1, { r(1, "lhs") }),
-      }),
+      lhs  = c(1, { sn(1, { t("<Leader>"), r(1, "lhs") }), sn(1, { r(1, "lhs") }) }),
       grp  = i(2, "group"),
       icon = i(0, "icon")
     }),
     { stored = { lhs = i(1, "lhs") } }
   ),
-  s({ trig = "wkeymap", name = "Keymap Config", dscr = "Keymap Config for which-key.nvim" },
+  s({ trig = "wkm", name = "Keymap Config", dscr = "Keymap Config for which-key.nvim" },
     fmta('{ "<lhs>", <rhs>, icon = "<icon> ", desc = "<desc>" },', {
       lhs = c(1, {
         sn(1, { t("<Leader>"), r(1, "user_lhs") }),
         sn(1, { r(1, "user_lhs") }),
       }),
       rhs = c(2, {
-        { t("<CMD>"), r(1, "user_rhs"), t("<CR>") },
+        { t("\"<CMD>"), r(1, "user_rhs"), t("<CR>\"") },
         { t("function()"), r(1, "user_rhs"), t("end") },
         { t(":"), r(1, "user_lhs"), t("<Space>") },
       }),


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Fix Lua keymap snippets by properly quoting command strings
- Shorten which-key snippet triggers (`wkeygrp` -> `wkg`, `wkeymap` -> `wkm`)

#### 🐞 Bug Fixes

<details>
<summary>fix(nvim): quote command string in lua keymap snippet (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/f5cb7db986b85b2ac3b40f658106e8fb284ad10f">f5cb7db</a>)</summary>

- Wrap <CMD> and <CR> tokens in double quotes
- Ensure generated keymap rhs is a valid string literal
- Shorten which-key group trigger from wkeygrp to wkg
- Shorten which-key mapping trigger from wkeymap to wkm
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #12345

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
