### PR TITLE
ci(renovate): update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,6 +36,7 @@
     {
       "customType": "regex",
       "description": ["Update Chezmoi version"],
+      "addLabels": ["CI/CD 🔁", "Deps 📦️", "chezmoi 🏘️"],
       "managerFilePatterns": ["^home/.chezmoiversion$"],
       "matchStrings": ["(?<currentValue>.*)\\s"],
       "depNameTemplate": "twpayne/chezmoi",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,6 +44,14 @@
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": ["aqua prefixed tool in mise toml files"],
+      "addLabels": ["CI/CD 🔁", "Deps 📦️", "mise ⚙️"],
+      "managerFilePatterns": ["^home/dot_config/mise/config\\.toml\\.tmpl$"],
+      "matchStrings": ["\"aqua:(?<depName>[^/]+/[^\"]+)\"\\s*=\\s*\"(?<currentValue>v?[^\"]+)\""],
+      "datasourceTemplate": "github-releases"
     }
   ],
   "mise": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,6 +60,14 @@
       "managerFilePatterns": ["^home/dot_config/mise/config\\.toml\\.tmpl$"],
       "matchStrings": ["\"github:(?<depName>[^/]+/[^\"]+)\"\\s*=\\s*\"(?<currentValue>v?[^\"]+)\""],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": ["npm prefixed tool in mise toml files"],
+      "addLabels": ["CI/CD 🔁", "Deps 📦️", "mise ⚙️"],
+      "managerFilePatterns": ["^home/dot_config/mise/config\\.toml\\.tmpl$"],
+      "matchStrings": ["\"npm:(?<depName>[^/]+/[^\"]+)\"\\s*=\\s*\"(?<currentValue>v?[^\"]+)\""],
+      "datasourceTemplate": "npm"
     }
   ],
   "mise": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,6 +52,14 @@
       "managerFilePatterns": ["^home/dot_config/mise/config\\.toml\\.tmpl$"],
       "matchStrings": ["\"aqua:(?<depName>[^/]+/[^\"]+)\"\\s*=\\s*\"(?<currentValue>v?[^\"]+)\""],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": ["github prefixed tool in mise toml files"],
+      "addLabels": ["CI/CD 🔁", "Deps 📦️", "mise ⚙️"],
+      "managerFilePatterns": ["^home/dot_config/mise/config\\.toml\\.tmpl$"],
+      "matchStrings": ["\"github:(?<depName>[^/]+/[^\"]+)\"\\s*=\\s*\"(?<currentValue>v?[^\"]+)\""],
+      "datasourceTemplate": "github-releases"
     }
   ],
   "mise": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    ":semanticCommits"
+    ":semanticCommits",
+    ":disableDependencyDashboard"
   ],
 
   "timezone": "Asia/Tokyo",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
   "prConcurrentLimit": 5,
   "assigneesFromCodeOwners": true,
 
+  "enabledManagers": ["github-actions", "mise"],
   "packageRules": [
     {
       "groupName": "github-actions",


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Disable the Renovate Dependency Dashboard to reduce automated issue noise
- Add descriptive labels (CI/CD, Deps, chezmoi) to chezmoi version updates
- Restrict Renovate to github-actions and mise managers for optimized scanning
- Add custom regex managers to track aqua, github, and npm prefixed tools in mise configuration

#### Other Changes

<details>
<summary>ci(renovate): add regex manager for npm tools in mise (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/eec0305d8c1e88cdd642b0f45b09c3d778928d05">eec0305</a>)</summary>

• Add custom regex manager to track npm: prefixed tools in mise
• Include CI/CD, Deps, and mise labels for automated PRs
• Configure npm datasource for correct version tracking of packages
</details>

<details>
<summary>ci(renovate): add regex manager for github tools in mise (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7f84fd124ab538204c7385ad739e1e69268202b1">7f84fd1</a>)</summary>

• Add custom regex manager to track github: prefixed tools in mise
• Include CI/CD, Deps, and mise labels for automated PRs
• Target mise configuration template for release-based version updates
</details>

<details>
<summary>ci(renovate): add regex manager for aqua tools in mise (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b28db84b5480f99e81c673945137583313d839a3">b28db84</a>)</summary>

• Add a new custom regex manager to track aqua: prefixed dependencies in mise configuration
• Configure labels for CI/CD, Deps, and mise for better PR categorization
• Target home/dot_config/mise/config.toml.tmpl for GitHub release based versioning
</details>

<details>
<summary>ci(renovate): restrict enabled managers (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/790837641d35c22c024a495efb2a2b06082c5c3f">7908376</a>)</summary>

• Add enabledManagers configuration to renovate.json
• Explicitly enable github-actions and mise managers
• Optimize scanning performance by limiting Renovate to specific file types
</details>

<details>
<summary>ci(renovate): add labels to chezmoi version updates (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b31d14719dab1e0d96fab40d22baca9db0a98d0c">b31d147</a>)</summary>

• Add addLabels configuration to the Chezmoi regex manager
• Include CI/CD, Deps, and chezmoi labels for better PR organization
• Improve visibility and filtering of automated version updates
</details>

<details>
<summary>ci(renovate): disable dependency dashboard (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/e7c88c926bcbfd5eecde33835326bda9c7d38e4f">e7c88c9</a>)</summary>

• Add :disableDependencyDashboard to the extends array
• Prevent Renovate from creating or updating the central dashboard issue
• Reduce automated issue noise in the repository
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1517

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
