### PR TITLE
feat(ai): update agent config

### DIFF
--- a/home/.chezmoidata/opencode.toml
+++ b/home/.chezmoidata/opencode.toml
@@ -12,7 +12,7 @@ instructions = [ "AGENTS.md", "CONTRIBUTING.md" ]
 enabled_providers = [ "anthropic", "google", "github-copilot" ]
 
 [opencode.models]
-sota    = "google/antigravity-claude-opus-4-5-thinking"
+sota    = "google/antigravity-claude-opus-4-6-thinking"
 elite   = "google/antigravity-claude-sonnet-4-5-thinking"
 general = "google/antigravity-gemini-3-pro"
 lite    = "google/antigravity-gemini-3-flash"
@@ -286,5 +286,14 @@ limit      = { context = 200000, output = 64000 }
 modalities = { input = ["text", "image", "pdf"], output = ["text"] }
 
 [opencode.providers.google.models."antigravity-claude-opus-4-5-thinking".variants]
+low = { thinkingConfig = { thinkingBudget = 8192  } }
+max = { thinkingConfig = { thinkingBudget = 32768  } }
+
+[opencode.providers.google.models."antigravity-claude-opus-4-6-thinking"]
+name       = "Claude Opus 4.5 Thinking (Antigravity)"
+limit      = { context = 200000, output = 64000 }
+modalities = { input = ["text", "image", "pdf"], output = ["text"] }
+
+[opencode.providers.google.models."antigravity-claude-opus-4-6-thinking".variants]
 low = { thinkingConfig = { thinkingBudget = 8192  } }
 max = { thinkingConfig = { thinkingBudget = 32768  } }

--- a/home/.chezmoidata/opencode.toml
+++ b/home/.chezmoidata/opencode.toml
@@ -6,7 +6,7 @@ autoshare  = false
 snapshot   = false
 theme      = "github"
 
-plugins = [ "oh-my-opencode@latest", "opencode-antigravity-auth@latest" ]
+plugins = [ "oh-my-opencode@latest", "opencode-antigravity-auth@beta" ]
 instructions = [ "AGENTS.md", "CONTRIBUTING.md" ]
 
 enabled_providers = [ "anthropic", "google", "github-copilot" ]

--- a/home/.chezmoiexternals/opencode.toml.tmpl
+++ b/home/.chezmoiexternals/opencode.toml.tmpl
@@ -9,13 +9,9 @@ refreshPeriod = "168h"
 {{ template "repo" }}
 url = "https://github.com/wshobson/commands"
 
-# renovate: datasource=github-releases depName=obra/superpowers
-{{ $superpowersVersion := "4.0.3" -}}
-
 ["Dev/repos/github.com/obra/superpowers"]
 {{ template "repo" }}
 url  = "https://github.com/obra/superpowers"
-args = ["--branch", {{ $superpowersVersion | quote }}]
 
 ["Dev/repos/github.com/awesome-claude-code-subagents"]
 {{ template "repo" }}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Updated state-of-the-art model to Claude Opus 4.6 for OpenCode
- Switched to beta version of `antigravity-auth` plugin
- Removed version pinning and branch tracking for `superpowers` repository

#### 🎉 New Features

<details>
<summary>feat(opencode): update sota model to claude-opus-4.6 (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/f97f50b60f7ac8c0ee943204b3c78fdaf0113086">f97f50b</a>)</summary>

- Update state-of-the-art model reference to Claude Opus 4.6
- Add configuration for antigravity-claude-opus-4-6-thinking model
- Define context limits and thinking budget variants for the new model
</details>

#### Other Changes

<details>
<summary>chore(opencode): use beta antigravity-auth plugin (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b1d79c4884dbbdbe15d40caeba1a85d078d383c7">b1d79c4</a>)</summary>

- Switch opencode-antigravity-auth from @latest to @beta
- Enable testing of pre-release authentication features
</details>

<details>
<summary>chore(opencode): remove version pinning for superpowers (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/2ff41303e869a30d392aaf1cd96193563d615a82">2ff4130</a>)</summary>

- Remove hardcoded version 4.0.3 for obra/superpowers repository
- Switch from branch-specific tracking to default branch
- Delete associated Renovate version tracking metadata
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1519

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
