### PR TITLE
Potential fix for code scanning alert no. 384: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -10,6 +10,9 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/MasahiroSakoda/dotfiles/security/code-scanning/384](https://github.com/MasahiroSakoda/dotfiles/security/code-scanning/384)

In general, fix this by adding an explicit `permissions` block either at the workflow root or under the specific job, granting only the scopes needed. For a semantic PR title check that only reads PR metadata, `contents: read` and `pull-requests: read` are typically sufficient.

For this specific workflow, the safest, non‑breaking approach is to add a `permissions` block to the `main` job (or at the top level) with read‑only scopes. Since the job only validates the PR title and does not push commits, create releases, or modify issues, it does not need any write permissions. We will therefore add:

```yaml
permissions:
  contents: read
  pull-requests: read
```

at the job level, just under `runs-on: ubuntu-latest`. No additional methods, imports, or other definitions are required; this is purely a YAML configuration change within `.github/workflows/semantic-pr.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
