### PR TITLE
Potential fix for code scanning alert no. 383: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -7,6 +7,9 @@ jobs:
   issue-labeler:
     name: Issue Labeler
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/MasahiroSakoda/dotfiles/security/code-scanning/383](https://github.com/MasahiroSakoda/dotfiles/security/code-scanning/383)

In general, the fix is to explicitly declare the minimal `permissions` required by each job that uses `GITHUB_TOKEN`, instead of relying on repository/organization defaults. This documents the intent and prevents accidental escalation if defaults change.

For this workflow, we only need to modify `.github/workflows/issue.yml`. The `issue-assign` job already has `permissions: issues: write`. The `issue-labeler` job needs its own `permissions` block. According to `actions/labeler` documentation for labeling issues/PRs based on configuration in the repo, it needs to read repository contents and write labels to issues (and possibly PRs, but this workflow is only triggered on `issues`). To avoid changing functionality while following least privilege, we can set:

- `contents: read` so the action can read `.github/labeler.yml` and repository metadata.
- `issues: write` so it can apply labels to issues.

We add this block under `issue-labeler` alongside `runs-on`, at the same indentation level as the existing `steps`. No imports or additional methods are required, just a YAML change in that file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
