### PR TITLE
feat: simplify renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
     {
       "description": "Group chezmoi updates",
       "matchManagers": ["custom.regex"],
-      "matchFileNames": ["^home/\\.chezmoiversion$", "^home/\\.chezmoiexternals/*\\.toml\\.tmpl$"],
+      "matchFileNames": ["/^home/\\.chezmoiversion$/", "/^home/\\.chezmoiexternals/*\\.toml\\.tmpl$/"],
       "groupName": "chezmoi",
       "addLabels": ["Deps 📦️", "chezmoi 🏘️"],
       "schedule": ["before 5am on the first day of the month"]
@@ -43,7 +43,7 @@
     {
       "customType": "regex",
       "description": ["Update Chezmoi version"],
-      "managerFilePatterns": ["^home/\\.chezmoiversion$"],
+      "managerFilePatterns": ["/^home/\\.chezmoiversion$/"],
       "matchStrings": ["(?<currentValue>.*)\\s"],
       "depNameTemplate": "twpayne/chezmoi",
       "datasourceTemplate": "github-releases",
@@ -52,6 +52,6 @@
     }
   ],
   "mise": {
-    "managerFilePatterns": [ "^home/dot_config/mise/config\\.toml\\.tmpl$" ]
+    "managerFilePatterns": [ "/^home/dot_config/mise/config\\.toml\\.tmpl/$" ]
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
     ":semanticCommits",
     ":disableDependencyDashboard",
     ":automergeMinor",
-		":automergeDigest"
+    ":automergeDigest",
+    ":separateMultipleMajorReleases"
   ],
 
   "timezone": "Asia/Tokyo",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,11 +18,9 @@
   "enabledManagers": ["github-actions", "mise", "custom.regex"],
   "packageRules": [
     {
-      "groupName": "github-actions",
+      "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
-      "pinDigests": true,
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "minimumReleaseAge": "3 days"
+      "groupName": "GitHub Actions"
     },
     {
       "groupName": "chezmoi",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,8 @@
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["^home/\\.chezmoiversion$", "^home/\\.chezmoiexternals/*\\.toml\\.tmpl$"],
       "groupName": "chezmoi",
-      "addLabels": ["Deps 📦️", "chezmoi 🏘️"]
+      "addLabels": ["Deps 📦️", "chezmoi 🏘️"],
+      "schedule": ["before 5am on the first day of the month"]
     },
     {
       "description": "Group mise updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,7 +20,8 @@
     {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
+      "groupName": "GitHub Actions",
+      "schedule": ["before 5am on the first day of the month"]
     },
     {
       "description": "Group chezmoi updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,11 +30,11 @@
       "addLabels": ["Deps 📦️", "chezmoi 🏘️"]
     },
     {
-      "groupName": "mise",
+      "description": "Group mise updates",
       "matchManagers": ["mise"],
+      "groupName": "mise",
       "addLabels": ["Deps 📦️", "mise ⚙️"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "minimumReleaseAge": "2 days"
+      "schedule": ["before 5am on monday"]
     }
   ],
   "customManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:best-practices",
     ":semanticCommits",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    ":automergeMinor"
   ],
 
   "timezone": "Asia/Tokyo",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
     "config:best-practices",
     ":semanticCommits",
     ":disableDependencyDashboard",
-    ":automergeMinor"
+    ":automergeMinor",
+		":automergeDigest"
   ],
 
   "timezone": "Asia/Tokyo",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,10 +23,11 @@
       "groupName": "GitHub Actions"
     },
     {
-      "groupName": "chezmoi",
+      "description": "Group chezmoi updates",
       "matchManagers": ["custom.regex"],
-      "addLabels": ["Deps 📦️", "chezmoi 🏘️"],
-      "matchUpdateTypes": ["minor", "patch", "digest"]
+      "matchFileNames": ["^home/\\.chezmoiversion$", "^home/\\.chezmoiexternals/*\\.toml\\.tmpl$"],
+      "groupName": "chezmoi",
+      "addLabels": ["Deps 📦️", "chezmoi 🏘️"]
     },
     {
       "groupName": "mise",
@@ -40,7 +41,7 @@
     {
       "customType": "regex",
       "description": ["Update Chezmoi version"],
-      "managerFilePatterns": ["^home/.chezmoiversion$"],
+      "managerFilePatterns": ["^home/\\.chezmoiversion$"],
       "matchStrings": ["(?<currentValue>.*)\\s"],
       "depNameTemplate": "twpayne/chezmoi",
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Simplified and refined Renovate configuration for better maintainability.
- Enabled automatic merging for minor updates and dependency digests.
- Standardized monthly update schedules for chezmoi and GitHub Actions.
- Improved regex pattern syntax and file matching for mise and chezmoi managers.
- Refined package grouping rules and removed constraints for faster updates.
- Configured separate Pull Requests for handling multiple major releases.

#### Other Changes

<details>
<summary>chore(renovate): fix regex patterns syntax (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/131fab9eb30e6a159a31d8dc37981f52baebb36a">131fab9</a>)</summary>

- Wrap file matching patterns in forward slashes to comply with Renovate regex requirements
- Update regex for chezmoi version and external template files
- Standardize manager file patterns for mise configuration
</details>

<details>
<summary>chore(renovate): schedule chezmoi updates monthly (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/80919056bf800a6cf3ce10b709177e12a8d7a7f6">8091905</a>)</summary>

- Add monthly schedule for chezmoi package updates
- Set execution time to before 5am on the first day of the month
- Align update frequency with GitHub Actions for consistency
</details>

<details>
<summary>chore(renovate): schedule github-actions updates monthly (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/ec432b1b97555b8baaf38912dbbf196d97cbb615">ec432b1</a>)</summary>

- Add monthly schedule for GitHub Actions package updates
- Set execution time to before 5am on the first day of the month
- Standardize update frequency to reduce maintenance noise
</details>

<details>
<summary>chore(renovate): refine mise package grouping (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/2d90f0fbfed1a3db94b0bbe332e9f00aa388bb27">2d90f0f</a>)</summary>

- Add description to mise package grouping for clarity
- Remove update type filters and minimum release age constraint
- Add weekly schedule to run before 5am on Mondays
- Reorder group properties for better organization
</details>

<details>
<summary>chore(renovate): refine chezmoi package grouping (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/0ff8f6ebdcdb8b55e5f338f572abff82712bd351">0ff8f6e</a>)</summary>

- Add description to chezmoi package grouping for clarity
- Update chezmoi package rules to use explicit file name patterns
- Fix regex escape sequence in manager file patterns for chezmoi
- Remove update type filters for the chezmoi group
</details>

<details>
<summary>chore(renovate): simplify github-actions package rules (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/968539fc0319da178794126884806044254a6418">968539f</a>)</summary>

- Add description to GitHub Actions package grouping for clarity
- Update group name for GitHub Actions to follow consistent casing
- Remove digest pinning and specific update type filters
- Remove minimum release age constraint to allow faster updates
</details>

<details>
<summary>chore(renovate): enable separate major release PRs (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/c32dc5d5ba3c9451077fc7a43f7f9397d0b660c5">c32dc5d</a>)</summary>

- Add :separateMultipleMajorReleases to the extends list
- Ensure multiple major releases are handled in separate Pull Requests
- Fix indentation for the :automergeDigest entry
</details>

<details>
<summary>chore(renovate): enable digest automerging (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/a7176ea653cc6212154176e551bb5a125130c0d7">a7176ea</a>)</summary>

- Add :automergeDigest to the configuration extends list
- Enable automatic merging for dependency digest updates
</details>

<details>
<summary>chore(renovate): enable automerge for minor updates (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/45f5f9ba9874baf35114956cebec09da79937a59">45f5f9b</a>)</summary>

- Add :automergeMinor to Renovate configuration presets
- Enable automatic merging of minor dependency updates to reduce manual maintenance
</details>
## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1528

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
