### PR TITLE
ci(renovate): update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,8 +35,7 @@
       "description": "Group mise updates",
       "matchManagers": ["mise"],
       "groupName": "mise",
-      "addLabels": ["Deps 📦️", "mise ⚙️"],
-      "schedule": ["before 5am on monday"]
+      "addLabels": ["Deps 📦️", "mise ⚙️"]
     }
   ],
   "customManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,8 +28,7 @@
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["/^home/\\.chezmoiversion$/", "/^home/\\.chezmoiexternals/*\\.toml\\.tmpl$/"],
       "groupName": "chezmoi",
-      "addLabels": ["Deps 📦️", "chezmoi 🏘️"],
-      "schedule": ["before 5am on the first day of the month"]
+      "addLabels": ["Deps 📦️", "chezmoi 🏘️"]
     },
     {
       "description": "Group mise updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,8 +20,7 @@
     {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "schedule": ["before 5am on the first day of the month"]
+      "groupName": "GitHub Actions"
     },
     {
       "description": "Group chezmoi updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,6 @@
     "config:best-practices",
     ":semanticCommits",
     ":disableDependencyDashboard",
-    ":automergeMinor",
-    ":automergeDigest",
     ":separateMultipleMajorReleases"
   ],
 
@@ -20,20 +18,23 @@
     {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
+      "groupName": "GitHub Actions",
+      "autoMerge": true
     },
     {
       "description": "Group chezmoi updates",
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["/^home/\\.chezmoiversion$/", "/^home/\\.chezmoiexternals/*\\.toml\\.tmpl$/"],
       "groupName": "chezmoi",
-      "addLabels": ["Deps 📦️", "chezmoi 🏘️"]
+      "addLabels": ["Deps 📦️", "chezmoi 🏘️"],
+      "autoMerge": true
     },
     {
       "description": "Group mise updates",
       "matchManagers": ["mise"],
       "groupName": "mise",
-      "addLabels": ["Deps 📦️", "mise ⚙️"]
+      "addLabels": ["Deps 📦️", "mise ⚙️"],
+      "autoMerge": false
     }
   ],
   "customManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
 
   "timezone": "Asia/Tokyo",
   "prHourlyLimit": 2,
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 10,
   "assigneesFromCodeOwners": true,
   "labels": ["CI/CD 🔁"],
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   ],
 
   "timezone": "Asia/Tokyo",
-  "prHourlyLimit": 2,
+  "prHourlyLimit": 5,
   "prConcurrentLimit": 10,
   "assigneesFromCodeOwners": true,
   "labels": ["CI/CD 🔁"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,6 +52,6 @@
     }
   ],
   "mise": {
-    "managerFilePatterns": [ "/^home/dot_config/mise/config\\.toml\\.tmpl/$" ]
+    "managerFilePatterns": [ "/^home/dot_config/mise/config\\.toml\\.tmpl$/" ]
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
     "config:best-practices",
     ":semanticCommits",
     ":disableDependencyDashboard",
+    ":automergeMinor",
+    ":automergePatch",
+    ":automergeDigest",
     ":separateMultipleMajorReleases"
   ],
 
@@ -18,23 +21,20 @@
     {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "autoMerge": true
+      "groupName": "GitHub Actions"
     },
     {
       "description": "Group chezmoi updates",
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["/^home/\\.chezmoiversion$/", "/^home/\\.chezmoiexternals/*\\.toml\\.tmpl$/"],
       "groupName": "chezmoi",
-      "addLabels": ["Deps 📦️", "chezmoi 🏘️"],
-      "autoMerge": true
+      "addLabels": ["Deps 📦️", "chezmoi 🏘️"]
     },
     {
       "description": "Group mise updates",
       "matchManagers": ["mise"],
       "groupName": "mise",
-      "addLabels": ["Deps 📦️", "mise ⚙️"],
-      "autoMerge": false
+      "addLabels": ["Deps 📦️", "mise ⚙️"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Update Renovate configuration to increase PR limits (hourly and concurrent)
- Refine Renovate auto-merge strategies and remove update schedules
- Fix file pattern for mise dependencies in Renovate

#### 🐞 Bug Fixes

<details>
<summary>fix(renovate): wrong `mise` related file pattern (<a
href="https://github.com/MasahiroSakoda/dotfiles/commit/ca6a273d3d821346884dfc97e34c211ba6a3968f">ca6a273</a>)</summary>

- Corrected file pattern for `home/dot_config/mise/config.toml.tmpl`
</details>

#### Other Changes

<details>
<summary>chore(ci): increase renovate hourly pr limit (<a
href="https://github.com/MasahiroSakoda/dotfiles/commit/2945cf310b32a1958d428a025b6c797fca1ffc65">2945cf3</a>)</summary>

- Update prHourlyLimit from 2 to 5 in Renovate configuration
- Allow Renovate to create more pull requests per hour to speed up dependency updates
</details>

<details>
<summary>chore(ci): increase renovate concurrent pr limit (<a
href="https://github.com/MasahiroSakoda/dotfiles/commit/a0d568e55e522b35d32ae2b69070ad495df415ae">a0d568e</a>)</summary>

- Update prConcurrentLimit from 5 to 10 in Renovate configuration
- Allow more simultaneous pull requests from Renovate to improve dependency update speed
</details>

<details>
<summary>ci(renovate): update auto merge strategies (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/c7d4d28831deb4fa8344074ea387f921a7db714e">c7d4d28</a>)</summary>

- Refined auto-merge logic for dependency updates
</details>

<details>
<summary>ci(renovate): remova schedule for github actions deps (<a
href="https://github.com/MasahiroSakoda/dotfiles/commit/445a041267128457af56e810ce48e71afbd17830">445a041</a>)</summary>

- Removed specific scheduling for GitHub Actions dependencies to allow immediate updates
</details>

<details>
<summary>ci(renovate): remove schedule for `chezmoi` deps update (<a
href="https://github.com/MasahiroSakoda/dotfiles/commit/36dfe4842b36547ca8dbd38535d97c1dd05fdf62">36dfe48</a>)</summary>

- Removed specific scheduling for chezmoi dependencies
</details>

<details>
<summary>ci(renovate): remove schedule for `mise` deps update (<a
href="https://github.com/MasahiroSakoda/dotfiles/commit/e38aeeca8d01e35785487ab726186d8dc95001ee">e38aeec</a>)</summary>

- Removed specific scheduling for mise dependencies
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1535

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
