### PR TITLE
feat: update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,11 +51,18 @@
       "versioningTemplate": "semver"
     },
     {
-      "custom": "regex",
-      "description": "Update aqua-prefixed tool versions",
+      "customType": "regex",
+      "description": "Update aqua-prefixed tool versions in mise config",
       "managerFilePatterns": ["home/dot_config/mise/config\\.toml\\tmpl$"],
       "matchStrings": ["\"aqua:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update npm-prefixed tool versions in mise config",
+      "managerFilePatterns": ["home/dot_config/mise/config\\.toml\\.tmpl$"],
+      "matchStrings": ["\"npm:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "npm"
     }
   ],
   "mise": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
     ":automergeMinor",
     ":automergePatch",
     ":automergeDigest",
-    ":separateMultipleMajorReleases"
+    ":separateMultipleMajorReleases",
+    "helpers:pinGitHubActionDigests"
   ],
 
   "timezone": "Asia/Tokyo",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
     {
       "description": "Group chezmoi updates",
       "matchManagers": ["custom.regex"],
-      "matchFileNames": ["/^home/\\.chezmoiversion$/", "/^home/\\.chezmoiexternals/*\\.toml\\.tmpl$/"],
+      "matchFileNames": ["home/\\.chezmoiversion$", "home/\\.chezmoiexternals/*\\.toml\\.tmpl$"],
       "groupName": "chezmoi",
       "addLabels": ["Deps 📦️", "chezmoi 🏘️"]
     },
@@ -41,8 +41,8 @@
     {
       "customType": "regex",
       "description": ["Update Chezmoi version"],
-      "managerFilePatterns": ["/^home/\\.chezmoiversion$/"],
-      "matchStrings": ["(?<currentValue>.*)\\s"],
+      "managerFilePatterns": ["home/\\.chezmoiversion$"],
+      "matchStrings": ["^(?<currentValue>.*)\\s$"],
       "depNameTemplate": "twpayne/chezmoi",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$",
@@ -50,6 +50,6 @@
     }
   ],
   "mise": {
-    "managerFilePatterns": [ "/^home/dot_config/mise/config\\.toml\\.tmpl$/" ]
+    "managerFilePatterns": [ "home/dot_config/mise/config\\.toml\\.tmpl$" ]
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,6 +49,13 @@
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$",
       "versioningTemplate": "semver"
+    },
+    {
+      "custom": "regex",
+      "description": "Update aqua-prefixed tool versions",
+      "managerFilePatterns": ["home/dot_config/mise/config\\.toml\\tmpl$"],
+      "matchStrings": ["\"aqua:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "github-releases"
     }
   ],
   "mise": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,7 @@
   "prHourlyLimit": 5,
   "prConcurrentLimit": 10,
   "assigneesFromCodeOwners": true,
+  "vulnerabilityAlerts": { "enabled": true },
   "labels": ["CI/CD 🔁"],
 
   "enabledManagers": ["github-actions", "mise", "custom.regex"],


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Update Renovate configuration for `mise` tools
- Add `npm:` prefixed tool version support
- Add custom regex manager for `aqua` tool versions
- Enable security features (vulnerability alerts, GitHub Action digest pinning)
- Fix regex patterns in Renovate configuration

#### Other Changes

<details>
<summary>chore(renovate): update configuration for mise tools (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/571a7b30be5775f2bf8924daf24af7344c114b0a">571a7b3</a>)</summary>

- Update custom manager to use `customType` property
- Add support for `npm:` prefixed tool versions in mise configuration
- Update manager descriptions for better clarity
</details>

<details>
<summary>ci(renovate): add regex manager for aqua tool versions (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/1544bf66e80731e0ea4756af0ec9a1de2e6c202d">1544bf6</a>)</summary>

- Add custom regex manager to Renovate configuration
- Support updating aqua-prefixed tool versions in mise config
- Use github-releases as datasource for version extraction
</details>

<details>
<summary>ci(renovate): enable vulnerability alerts (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/241a27f56a6d80b33451891211e6402c04936e9c">241a27f</a>)</summary>

- Enable vulnerability alerts in Renovate configuration
- Improve security by automating updates for known vulnerabilities
</details>

<details>
<summary>ci(renovate): add github action digest pinning (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/575fdc1555b0ec8f9f52f993a38b87d3c3cd1ef2">575fdc1</a>)</summary>

- Add helpers:pinGitHubActionDigests to Renovate configuration
- Enable automatic pinning of GitHub Actions to digests for enhanced security and immutability
</details>

<details>
<summary>ci(renovate): correct regex patterns in configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/f7e1fafaea1e4ba81ef3665b8253108e16fe9321">f7e1faf</a>)</summary>

- Remove leading slash and start anchor from file matching patterns
- Add start and end anchors to version extraction regex for precision
- Ensure consistent path matching for chezmoi and mise configuration files
</details>
## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1541

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
