### PR TITLE
feat: refine renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -66,6 +66,13 @@
     },
     {
       "customType": "regex",
+      "description": "Update github-prefixed tool versions in mise config",
+      "managerFilePatterns": ["home/dot_config/mise/config\\.toml\\.tmpl$"],
+      "matchStrings": ["\"github:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
       "description": "Update npm-prefixed tool versions in mise config",
       "managerFilePatterns": ["home/dot_config/mise/config\\.toml\\.tmpl$"],
       "matchStrings": ["\"npm:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,7 +41,7 @@
     {
       "groupName": "mise",
       "description": "Group mise updates",
-      "matchManagers": ["mise"],
+      "matchManagers": ["custom.regex"],
       "matchFileNames": ["home/dot_config/mise/config\\.toml\\tmpl$"],
       "addLabels": ["mise ⚙️"]
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
   "prConcurrentLimit": 10,
   "assigneesFromCodeOwners": true,
   "vulnerabilityAlerts": { "enabled": true },
-  "labels": ["CI/CD 🔁"],
+  "labels": ["CI/CD 🔁", "Deps 📦️"],
 
   "enabledManagers": ["github-actions", "mise", "custom.regex"],
   "packageRules": [
@@ -30,13 +30,13 @@
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["home/\\.chezmoiversion$", "home/\\.chezmoiexternals/*\\.toml\\.tmpl$"],
       "groupName": "chezmoi",
-      "addLabels": ["Deps 📦️", "chezmoi 🏘️"]
+      "addLabels": ["chezmoi 🏘️"]
     },
     {
       "description": "Group mise updates",
       "matchManagers": ["mise"],
       "groupName": "mise",
-      "addLabels": ["Deps 📦️", "mise ⚙️"]
+      "addLabels": ["mise ⚙️"]
     }
   ],
   "customManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,22 +27,22 @@
       "automerge": true
     },
     {
+      "groupName": "GitHub Actions",
       "description": "Group GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
+      "matchManagers": ["github-actions"]
     },
     {
+      "groupName": "chezmoi",
       "description": "Group chezmoi updates",
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["home/\\.chezmoiversion$", "home/\\.chezmoiexternals/*\\.toml\\.tmpl$"],
-      "groupName": "chezmoi",
       "addLabels": ["chezmoi 🏘️"]
     },
     {
+      "groupName": "mise",
       "description": "Group mise updates",
       "matchManagers": ["mise"],
       "matchFileNames": ["home/dot_config/mise/config\\.toml\\tmpl$"],
-      "groupName": "mise",
       "addLabels": ["mise ⚙️"]
     }
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,7 @@
     {
       "description": "Group mise updates",
       "matchManagers": ["mise"],
+      "matchFileNames": ["home/dot_config/mise/config\\.toml\\tmpl$"],
       "groupName": "mise",
       "addLabels": ["mise ⚙️"]
     }
@@ -65,7 +66,5 @@
       "datasourceTemplate": "npm"
     }
   ],
-  "mise": {
-    "managerFilePatterns": [ "home/dot_config/mise/config\\.toml\\.tmpl$" ]
-  }
+  "mise": { "managerFilePatterns": ["home/dot_config/mise/config\\.toml\\.tmpl$"] }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,7 +29,8 @@
     {
       "groupName": "GitHub Actions",
       "description": "Group GitHub Actions updates",
-      "matchManagers": ["github-actions"]
+      "matchManagers": ["github-actions"],
+      "schedule": ["* * 1,15 * *"]
     },
     {
       "groupName": "chezmoi",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,6 @@
     "config:best-practices",
     ":semanticCommits",
     ":disableDependencyDashboard",
-    ":automergeMinor",
-    ":automergePatch",
-    ":automergeDigest",
     ":separateMultipleMajorReleases",
     "helpers:pinGitHubActionDigests"
   ],
@@ -20,6 +17,15 @@
 
   "enabledManagers": ["github-actions", "mise", "custom.regex"],
   "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "minimumReleaseAge": "2 weeks"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    },
     {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Refined Renovate configuration for GitHub Actions, mise, and dependency management.
- Improved Renovate automerge logic with release age constraints and explicit update types.
- Simplified labeling and standardized property ordering in Renovate rules.
- Added a custom regex manager to detect and update github-prefixed tools in mise templates.

#### Other Changes

<details>
<summary>ci(renovate): schedule GitHub Actions updates (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b46336cbf60047d8c10ebedb094b7574d72421e0">b46336c</a>)</summary>

- Update GitHub Actions group configuration in Renovate
- Set update schedule to run on the 1st and 15th of every month
</details>

<details>
<summary>chore(renovate): add custom manager for github tools (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/a60b2e4def32ef86ea55ec64cb01e284f6c1712a">a60b2e4</a>)</summary>

- Add regex configuration to detect github-prefixed tools in mise template
- Use github-releases datasource for automated version discovery
- Target home/dot_config/mise/config.toml.tmpl for updates
</details>

<details>
<summary>build(renovate): refine mise update grouping (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/896089eb52757263dbc0e3dd821fce2189d85479">896089e</a>)</summary>

- Update matchManagers to use custom.regex for mise updates
- Ensure correct grouping for mise configuration template files
</details>

<details>
<summary>style(ci): reorder Renovate package rules properties (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/463b8df39280e2495a9bf2a19b0fdab446906a19">463b8df</a>)</summary>

- Move groupName to the top of each package rule definition
- Standardize property ordering across all Renovate rules
- Improve readability of the Renovate configuration file
</details>

<details>
<summary>chore(ci): refine Renovate automerge configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/9d83c66af49000b5f5971e11bfb7a0d1a8d07796">9d83c66</a>)</summary>

- Update package rules to explicitly handle automerge by update type
- Set 2-week minimum release age for major updates to prevent breaking changes
- Enable automerge for minor, patch, and digest updates in package rules
- Remove redundant automerge presets from the configuration extends section
</details>

<details>
<summary>chore(ci): refine Renovate mise configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/9963e86bebbd3d1c8242e938219d66160107d03a">9963e86</a>)</summary>

- Add matchFileNames to mise package rule for targeted updates
- Consolidate mise managerFilePatterns configuration into a single line
- Improve identification of mise configuration templates for dependency updates
</details>

<details>
<summary>chore(ci): simplify Renovate labeling configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/84a3ce95827bccb3a5a431be2032f11add1ea6db">84a3ce9</a>)</summary>

- Move 'Deps 📦️' label to the global labels configuration
- Remove redundant label assignments from package rules for chezmoi and mise
- Ensure consistent labeling across all managed dependencies
</details>
## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1547

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
