### PR TITLE
feat: Update LSP config

### DIFF
--- a/home/dot_config/nvim/lua/lsp/config/init.lua
+++ b/home/dot_config/nvim/lua/lsp/config/init.lua
@@ -3,8 +3,6 @@ require("lsp.config.status")
 require("lsp.config.diagnostics")
 require("lsp.config.handlers")
 
-local active_clients = vim.lsp.get_clients()
-
 local on_attach = function(client, bufnr)
   local caps = client.server_capabilities
 
@@ -24,22 +22,6 @@ local on_attach = function(client, bufnr)
   caps.document_range_formatting  = true
   caps.documentFormattingProvider = true
   caps.offsetEncoding = { "utf-16" }
-
-  -- Avoid confliction ts_ls & denols
-  if client.name == "ts_ls" then
-    -- prevent prettier formatting confliction
-    caps.documentFormattingProvider = false
-    caps.documentRangeFormattingProvider = false
-    for _, _client in ipairs(active_clients) do
-      -- stop ts_ls if denols is already active
-      if _client.name == "denols" then client:stop(true) end
-    end
-  elseif client.name == "denols" then
-    -- prevent ts_ls from starting if denols is already active
-    for _, _client in ipairs(active_clients) do
-      if _client.name == "ts_ls" then client:stop(true) end
-    end
-  end
 
   -- Workaround semantic token problem go/gopls #54531
   if client.name == "gopls" and not caps.semanticTokensProvider then

--- a/home/dot_config/nvim/lua/lsp/config/init.lua
+++ b/home/dot_config/nvim/lua/lsp/config/init.lua
@@ -42,6 +42,6 @@ for server, config in pairs(servers) do
   if vim.tbl_isempty(config) then goto continue end
 
   vim.lsp.config(server, vim.tbl_deep_extend("keep", server_opts, config or {}))
-  -- vim.lsp.enable(server)
+  vim.lsp.enable(server)
   ::continue::
 end

--- a/home/dot_config/nvim/lua/lsp/config/typescript.lua
+++ b/home/dot_config/nvim/lua/lsp/config/typescript.lua
@@ -1,0 +1,25 @@
+-- -*-mode:lua-*- vim:ft=lua
+local ok, tstools = pcall(require, "typescript-tools")
+if not ok then return end
+
+tstools.setup({
+  on_attach = function(client, bufnr)
+    -- Disable tsserver's formatting capability to prevent conflict
+    client.server_capabilities.documentFormattingProvider      = false
+    client.server_capabilities.documentRangeFormattingProvider = false
+    if client.server_capabilities.inlayHintProvider then
+      vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
+    end
+  end,
+  capabilities = require("lsp.config.capabilities"),
+  settings = {
+    separate_diagnostic_server = true,
+    publish_diagnostic_on = "insert_leave",
+    tsserver_plugins = {},
+    tsserver_file_preferences = {
+      includeInlayParameterNameHints = "all",
+      includeCompletionsForModuleExports = true,
+      quotePreference = "auto",
+    },
+  },
+})

--- a/home/dot_config/nvim/lua/lsp/servers/dockerls.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/dockerls.lua
@@ -2,9 +2,15 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd          = { "docker-langserver", "--stdio" },
-  filetypes    = { "Dockerfile", "dockerfile" },
-  root_markers = { "Dockerfile", ".dockerignore" },
+  cmd          = { "docker-language-server", "--stdio" },
+  filetypes    = { "Dockerfile", "dockerfile", "yaml.docker-compose" },
+  get_language_id = function(_, ftype)
+  end,
+  root_markers = {
+    "Dockerfile",
+    "docker-compose.yaml", "docker-compose.yml", "compose.yaml", "compose.yml",
+    "docker-bake.json", "docker-bake.hcl", "docker-bake.override.json", "docker-bake.override.hcl",
+  },
   log_level = vim.lsp.protocol.MessageType.Warning,
   single_file_support = true,
   settings  = {},

--- a/home/dot_config/nvim/lua/lsp/servers/dockerls.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/dockerls.lua
@@ -5,6 +5,11 @@ return {
   cmd          = { "docker-language-server", "--stdio" },
   filetypes    = { "Dockerfile", "dockerfile", "yaml.docker-compose" },
   get_language_id = function(_, ftype)
+    if ftype == "yaml.docker-compose" or ftype:lower():find("ya?ml") then
+      return "dockercompose"
+    else
+      return ftype
+    end
   end,
   root_markers = {
     "Dockerfile",

--- a/home/dot_config/nvim/lua/lsp/servers/init.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/init.lua
@@ -12,7 +12,7 @@ return {
   ty            = require("lsp.servers.ty"),            -- Python
   ruby_lsp      = require("lsp.servers.ruby_ls"),       -- Ruby
   lua_ls        = require("lsp.servers.lua_ls"),        -- Lua
-  ts_ls         = require("lsp.servers.ts_ls"),         -- JS/TS
+  -- ts_ls         = require("lsp.servers.ts_ls"),         -- JS/TS
   denols        = require("lsp.servers.denols"),        -- Deno
   tailwindcss   = require("lsp.servers.tailwindcss"),   -- tailwindcss
   jsonls        = require("lsp.servers.jsonls"),        -- JSON

--- a/home/dot_config/nvim/lua/lsp/servers/init.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/init.lua
@@ -2,7 +2,8 @@
 
 return {
   -- LSP
-  copilot       = require("lsp.servers.copilot"),       -- GitHub Copilot
+  -- TODO: Enable Copilot language server once its memory consumption issue is resolved.
+  -- copilot       = require("lsp.servers.copilot"),       -- GitHub Copilot
   clangd        = require("lsp.servers.clangd"),        -- C/C++, ObjC, Swift, Rust
   gopls         = require("lsp.servers.gopls"),         -- Go
   rust_analyzer = require("lsp.servers.rust_analyzer"), -- Rust

--- a/home/dot_config/nvim/lua/plugins/lsp.lua
+++ b/home/dot_config/nvim/lua/plugins/lsp.lua
@@ -14,4 +14,10 @@ return {
     end,
   },
   { "b0o/schemastore.nvim" },
+  {
+    "pmizio/typescript-tools.nvim",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    ft = { "typescript", "typescriptreact", "ypescript.tsx" },
+    config = function() require("lsp.config.typescript") end,
+  },
 }


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add `get_language_id` function to `dockerls` for better `docker-compose` support
- Ensure all configured LSP servers are correctly enabled and initialized
- Migrate from `ts_ls` to `typescript-tools.nvim` for improved performance
- Enhance Docker language server configuration with broader root markers
- Disable Copilot LSP server to mitigate high memory consumption

#### 🎉 New Features

<details>
<summary>feat(nvim/lsp): switch from ts_ls to typescript-tools.nvim (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/e301c13d66488607a75b9434e8dee3ab2ad8c7f6">e301c13</a>)</summary>

- Replace the standard ts_ls server with typescript-tools.nvim for better performance
- Add new configuration file typescript.lua to manage TypeScript-specific LSP settings
- Remove manual conflict handling logic for ts_ls and denols from the main LSP config
- Register typescript-tools.nvim in the plugin list with appropriate filetype triggers
</details>

<details>
<summary>feat(nvim/lsp): enhance docker-language-server config (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/694ea8fea56a72c6a6de9f8b97375078f8ae261f">694ea8f</a>)</summary>

- Update language server command to 'docker-language-server'
- Add support for 'yaml.docker-compose' filetype
- Expand root markers to include docker-compose and docker-bake files
- Add empty 'get_language_id' function placeholder
</details>

#### 🐞 Bug Fixes

<details>
<summary>fix(lsp): correct language id for docker-compose files (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/2a4015a5a923e9536f9653e99a56df179b782dba">2a4015a</a>)</summary>

- Update dockerls configuration to handle yaml.docker-compose filetypes
- Map yaml-based docker-compose filetypes to dockercompose language ID
- Improve language server compatibility for Docker Compose files
</details>

<details>
<summary>fix(nvim/lsp): enable configured lsp servers (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/ad6ba5ce5166aa9ea2c382eac4c2296e18a0fc69">ad6ba5c</a>)</summary>

- Uncomment vim.lsp.enable(server) to ensure all configured servers are started
- Ensure the loop correctly initializes each server with merged options
</details>

#### Other Changes

<details>
<summary>perf(nvim/lsp): disable copilot server (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/89c330c10bfbfc94a7b69e52bbe4fc5c9a5eedee">89c330c</a>)</summary>

- Comment out copilot server to resolve high memory consumption
- Add TODO to re-enable once performance issues are addressed
- Improve Neovim resource efficiency by disabling copilot LSP
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1561

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
