### PR TITLE
feat: Update AI agent config

### DIFF
--- a/home/.chezmoidata/opencode.toml
+++ b/home/.chezmoidata/opencode.toml
@@ -9,7 +9,13 @@ theme      = "github"
 plugins = [ "oh-my-opencode@latest", "opencode-antigravity-auth@beta" ]
 instructions = [ "AGENTS.md", "CONTRIBUTING.md" ]
 
-enabled_providers = [ "opencode", "anthropic", "google", "github-copilot", "ollama" ]
+enabled_providers = [
+  "opencode",
+  # "anthropic",
+  "google",
+  "github-copilot",
+  "ollama"
+]
 
 [opencode.models]
 sota    = "google/antigravity-claude-opus-4-6-thinking"

--- a/home/.chezmoidata/opencode.toml
+++ b/home/.chezmoidata/opencode.toml
@@ -9,7 +9,7 @@ theme      = "github"
 plugins = [ "oh-my-opencode@latest", "opencode-antigravity-auth@beta" ]
 instructions = [ "AGENTS.md", "CONTRIBUTING.md" ]
 
-enabled_providers = [ "anthropic", "google", "github-copilot", "ollama" ]
+enabled_providers = [ "opencode", "anthropic", "google", "github-copilot", "ollama" ]
 
 [opencode.models]
 sota    = "google/antigravity-claude-opus-4-6-thinking"

--- a/home/dot_config/opencode/config.json.tmpl
+++ b/home/dot_config/opencode/config.json.tmpl
@@ -45,6 +45,7 @@
 
   {{/* Formatter Configurations */ -}}
   "formatter": {
+    "markdownlint-cli2": { "command": [ "markdownlint-cli2", "--fix", "$FILE" ], "extensions": [ ".md", ".mdx" ] },
     "biome": { "command": [ "biome", "format", "$FILE" ], "extensions": [".js", "jsx", ".ts", ".tsx"] },
     "shfmt": { "command": ["shfmt", "$FILE"], "extensions": [".sh", ".bash", ".zsh"] },
     "ruff": { "command": [ "ruff", "format", "$FILE" ], "extensions": [".py", ".pyi"] },

--- a/home/dot_config/opencode/config.json.tmpl
+++ b/home/dot_config/opencode/config.json.tmpl
@@ -26,7 +26,7 @@
     "ignore": {{ .opencode.watcher.ignore | toPrettyJson | indent 4 | trim }}
   },
 
-  {{/* Global AI Provier config */ -}}
+  {{/* Global AI Provider config */ -}}
   "enabled_providers": {{ .opencode.enabled_providers | toPrettyJson | indent 2 | trim | wrap 100 }},
 
   "provider": {{ .opencode.providers | toPrettyJson | indent 2 | trim }},
@@ -54,7 +54,7 @@
     "gofmt": { "command": ["golangci-lint", "format", "$FILE"], "extensions": [".go"] }
   },
 
-  {{/* Langage Server Configurations */ -}}
+  {{/* Language Server Configurations */ -}}
   {{- $servers := dict -}}
   {{- range $key, $value := .lsp.servers -}}
   {{-   if hasKey $value "cmd" -}}

--- a/home/dot_config/opencode/oh-my-opencode.json.tmpl
+++ b/home/dot_config/opencode/oh-my-opencode.json.tmpl
@@ -12,8 +12,6 @@
     "sisyphus":          { "model": {{ .opencode.models.sota | quote }} },
     {{/* The Legitimate Craftsman. Autonomous deep worker inspired by AmpCode's deep mode. Goal-oriented execution with thorough research before action. Explores codebase patterns, completes tasks end-to-end without premature stopping. Named after the Greek god of forge and craftsmanship. */ -}}
     "hephaestus":        { "model": {{ .opencode.models.elite | quote }} },
-    {{/*  The workhorse that actually writes code */ -}}
-    "sisyphus-junior":   { "model": {{ .opencode.models.elite | quote }} },
     {{/* Architecture decisions, code review, debugging. Read-only consultation - stellar logical reasoning and deep analysis. Inspired by AmpCode. */ -}}
     "oracle":            { "model": {{ .opencode.models.elite | quote }} },
     {{/* Multi-repo analysis, documentation lookup, OSS implementation examples. Deep codebase understanding with evidence-based answers. Inspired by AmpCode. */ -}}
@@ -30,8 +28,12 @@
     "metis":      { "model": {{ .opencode.models.elite | quote }} },
     {{/* Plan reviewer - validates plans against clarity, verifiability, and completeness standards. */ -}}
     "momus":      { "model": {{ .opencode.models.elite | quote }} },
-    {{/* Plan Executor: /start-work to activate */ -}}
-    "atlas":      { "model": {{ .opencode.models.elite | quote }} }
+
+    {{/*********** Orchestration Agents ***********/ -}}
+    {{/* Todo-list orchestrator. Executes planned tasks systematically, managing todo items and coordinating work. */ -}}
+    "atlas":      { "model": {{ .opencode.models.elite | quote }} },
+    {{/*  Category-spawned executor. Model is selected automatically based on the task category (visual-engineering, quick, deep, etc.). Used when the main agent delegates work via the task tool. */ -}}
+    "sisyphus-junior":   { "model": {{ .opencode.models.elite | quote }} }
   },
   "categories": {
     {{/* Frontend, UI/UX, design, styling, animation */ -}}

--- a/home/dot_config/opencode/oh-my-opencode.json.tmpl
+++ b/home/dot_config/opencode/oh-my-opencode.json.tmpl
@@ -10,6 +10,8 @@
     {{/*********** Core Agents ***********/ -}}
     {{/* The default orchestrator. Plans, delegates, and executes complex tasks using specialized subagents with aggressive parallel execution. Todo-driven workflow with extended thinking (32k budget). */ -}}
     "sisyphus":          { "model": {{ .opencode.models.sota | quote }} },
+    {{/* The Legitimate Craftsman. Autonomous deep worker inspired by AmpCode's deep mode. Goal-oriented execution with thorough research before action. Explores codebase patterns, completes tasks end-to-end without premature stopping. Named after the Greek god of forge and craftsmanship. */ -}}
+    "hephaestus":        { "model": {{ .opencode.models.elite | quote }} },
     {{/*  The workhorse that actually writes code */ -}}
     "sisyphus-junior":   { "model": {{ .opencode.models.elite | quote }} },
     {{/* Architecture decisions, code review, debugging. Read-only consultation - stellar logical reasoning and deep analysis. Inspired by AmpCode. */ -}}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Enable "opencode" provider and disable "anthropic" provider
- Add "hephaestus" agent for autonomous deep work
- Reorganize agent definitions by specialized orchestration roles
- Add `markdownlint-cli2` to the list of formatters
- Fix typos in configuration template comments

#### 🎉 New Features

<details>
<summary>feat(opencode): add hephaestus agent configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/e692e7350c6e729940ace0cbe7d2d0ca9bd522b4">e692e735</a>)</summary>

- Add the "hephaestus" agent for autonomous deep work and craftsmanship
- Configure the new agent to use the elite model from the opencode data
- Include a detailed description of the agent's goal-oriented execution patterns
</details>

<details>
<summary>feat(opencode): add markdownlint-cli2 to formatters (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/cd797b2fbaf7c11d5ec03db1d56fc93c438caea3">cd797b2f</a>)</summary>

- Add `markdownlint-cli2` with `--fix` flag to the list of formatters
- Support formatting for `.md` and `.mdx` files
</details>

<details>
<summary>feat(opencode): enable opencode provider (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/8799706497b0548cf147d0cb6f5bbdfdbd07bbd7">87997064</a>)</summary>

- Add "opencode" to the list of `enabled_providers` in `.chezmoidata/opencode.toml`
- This allows the "opencode" provider to be used within the tool configuration.
</details>

#### Other Changes

<details>
<summary>chore(opencode): disable anthropic provider (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/40188988de4bcca89b6e30bd0759fcb097b8ef12">40188988</a>)</summary>

- Comment out "anthropic" from enabled_providers list
- Reformat enabled_providers array for improved readability
</details>

<details>
<summary>refactor(opencode): reorganize agent definitions by role (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/018301443c1107ea97c480fd26b07e3ae885cfe4">01830144</a>)</summary>

- Create "Orchestration Agents" section in oh-my-opencode configuration
- Move sisyphus-junior and atlas agents to the new orchestration section
- Update agent descriptions to reflect specialized orchestration roles
- Standardize the categorization of core versus task-driven agents
</details>

<details>
<summary>style(opencode): fix typos in config template comments (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/bc2b87758ba435397f814326832b8425b44e5d47">bc2b8775</a>)</summary>

- Correct "Provier" to "Provider" in AI Provider section
- Correct "Langage" to "Language" in Language Server section
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1572

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
