### PR TITLE
feat: Update nvim keymaps

### DIFF
--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -382,10 +382,8 @@ if not is_vscode then
     { "\\s", "<CMD>Sidekick nes toggle<CR>", icon = "󰁤 ", desc = " Next Edit Suggestion" },
 
     -- CLI
-    { "<Leader>ap", "<CMD>Sidekick cli prompt<CR>",                          icon = "󰞷 ", desc = " Prompt Menu" },
-    { "<C-.>",      "<CMD>Sidekick cli focus<CR>",              mode = nxo,  icon = "󰽎 ", desc = " Switch Focus" },
-    { "<Leader>aa", "<CMD>Sidekick cli toggle name=opencode focus=true<CR>", icon = " ", desc = " OpenCode" },
-    { "<Leader>ag", "<CMD>Sidekick cli toggle name=gemini focus=true<CR>",   icon = " ", desc = " Gemini CLI" },
+    { "<Leader>ap", "<CMD>Sidekick cli prompt<CR>",             icon = "󰞷 ", desc = " Prompt Menu" },
+    { "<C-.>",      "<CMD>Sidekick cli toggle<CR>", mode = nxo, icon = "󰽎 ", desc = " Switch Focus" },
 
     { "<Leader>at", "<CMD>Sidekick cli send msg='{this}'<CR>",       mode = nx,icon = "󰞷 ",desc = " Send Line" },
     { "<Leader>av", "<CMD>Sidekick cli send msg='{selection}'<CR>",  mode = nx,icon = "󰞷 ",desc = " Send Selection" },

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -25,6 +25,17 @@ vim.cmd.cnoreabbrev("Wq", "wq")
 vim.cmd.cnoreabbrev("WQ", "wq")
 
 ---------------------------------------------------------------------------
+-- Groups
+---------------------------------------------------------------------------
+wk.add({
+  { "[",  group = "Prev",     icon = "󰒮 ", desc = " Prev" },
+  { "]",  group = "Next",     icon = "󰒭 ", desc = " Next" },
+  { "g",  group = "Go to",    icon = " ", desc = " Go to" },
+  { "gs", group = "Surround", icon = "󰅪 ", desc = " Surround" },
+  { "z",  group = "Fold",     icon = " ", desc = " Fold / Cursor" },
+})
+
+---------------------------------------------------------------------------
 -- which-key: <Leader> + w
 ---------------------------------------------------------------------------
 wk.add({

--- a/home/dot_config/nvim/lua/user/surround.lua
+++ b/home/dot_config/nvim/lua/user/surround.lua
@@ -3,6 +3,7 @@ local ok, surround = pcall(require, "nvim-surround")
 if not ok then return end
 
 surround.setup({
+  highlight = { duration = 200 },
   keymaps = {
     normal      = "gs",
     normal_cur  = false,

--- a/home/dot_config/nvim/lua/user/surround.lua
+++ b/home/dot_config/nvim/lua/user/surround.lua
@@ -17,3 +17,6 @@ surround.setup({
     delete      = "gsd"
   },
 })
+
+-- Prevent overlap warning
+vim.keymap.del("n", "gs")

--- a/home/dot_config/nvim/lua/user/surround.lua
+++ b/home/dot_config/nvim/lua/user/surround.lua
@@ -3,16 +3,16 @@ local ok, surround = pcall(require, "nvim-surround")
 if not ok then return end
 
 surround.setup({
-  kemaps = {
-    insert      = "<C-g>s",
-    insert_line = "<C-g>S",
-    normal      = "yss",
-    normal_cur  = "yS",
-    normal_line = "ySS",
-    visual      = "gS",
-    visual_line = "gS",
-    delete      = "ds",
-    change      = "cs",
-    change_line = "cS",
+  keymaps = {
+    normal      = "gs",
+    normal_cur  = false,
+    normal_line = false,
+    insert      = "<C-y>s",
+    insert_line = "<C-y>s",
+    visual      = "gs",
+    visual_line = false,
+    change      = "gsc",
+    change_line = false,
+    delete      = "gsd"
   },
 })


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add highlight duration to surround setup for better visual feedback
- Resolve surround keymap overlap warnings and fix typos
- Add which-key groups for better organization and navigation
- Simplify sidekick CLI keymaps with a unified toggle command

#### 🎉 New Features

<details>
<summary>feat(nvim): add highlight duration to surround setup (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/003dfc39224c2d402fe8d2acda6dc64f2236522f">003dfc3</a>)</summary>

• Enable visual feedback for surround operations
• Set highlight duration to 200ms in nvim-surround configuration
</details>

#### 🐞 Bug Fixes

<details>
<summary>fix(nvim): resolve surround keymap overlap warning (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/1fc3c7ecde30536d436a543c026132adb3ed5753">1fc3c7e</a>)</summary>

• Delete default `gs` keymap to prevent prefix overlap
• Enable `nvim-surround` to use `gs` without warning
• Improve keymap stability in Neovim configuration
</details>

<details>
<summary>fix(nvim): correct surround keymaps typo and update bindings (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/8581c6b89e1b8e12f3f7b15bb0b192daad65588d">8581c6b</a>)</summary>

• Fix typo from 'kemaps' to 'keymaps' in surround setup
• Redesign keybindings to use 'gs' prefix for normal and visual modes
• Update insert mode mappings to use '<C-y>s'
• Consolidate change and delete mappings to 'gsc' and 'gsd'
</details>

#### Other Changes

<details>
<summary>style(nvim): add which-key groups for better organization (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/2e46262335b5ede4ab9b6eac6819787a902a08e5">2e46262</a>)</summary>

• Add visual groups for navigation and text manipulation
• Define groups for Prev ([), Next (]), and Go to (g)
• Include dedicated groups for Surround (gs) and Fold/Cursor (z)
• Enhance keymap readability with descriptive icons and labels
</details>

<details>
<summary>refactor(nvim): simplify sidekick cli keymaps (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/bc133c24a68c1a5ea6126b75d977f6509e0048f3">bc133c2</a>)</summary>

• Replace specific CLI toggles with a unified toggle command
• Update <C-.> mapping to use the toggle command instead of focus
• Remove individual mappings for OpenCode and Gemini CLI
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1576

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
