### PR TITLE
feat: Update Ghostty config

### DIFF
--- a/home/.chezmoidata/ghostty.toml
+++ b/home/.chezmoidata/ghostty.toml
@@ -26,6 +26,9 @@ background = "#bf616a"
 [ghostty.modes.vim]
 enabled = true
 
+[ghostty.modes.resize]
+enabled = true
+
 [ghostty.shader]
 enabled = false
 animate = true

--- a/home/.chezmoidata/ghostty.toml
+++ b/home/.chezmoidata/ghostty.toml
@@ -23,6 +23,9 @@ background = "#ebcbbb"
 foreground = "#2e3440"
 background = "#bf616a"
 
+[ghostty.modes.vim]
+enabled = true
+
 [ghostty.shader]
 enabled = false
 animate = true

--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -110,7 +110,7 @@ font-thicken-strength = 1
 ## Notification
 notify-on-command-finish        = unfocused
 notify-on-command-finish-action = bell,notify
-notify-on-command-finish-after  = 10s
+notify-on-command-finish-after  = 30s
 
 ## Keymap: `ghostty +list-keybinds`
 keybind = shift+enter=text:\n

--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -210,3 +210,17 @@ keybind = vim/v=copy_to_clipboard
 ##### Command Palette
 keybind = vim/shift+semicolon=toggle_command_palette
 {{- end }}
+
+{{- if .ghostty.modes.vim.enabled }}
+#### Resize mode
+
+##### Enter / Exit resize mode
+keybind = super+r=activate_key_table:resize
+keybind = resize/escape=deactivate_key_table
+keybind = resize/catch_all=ignore
+
+keybind = resize/arrow_up=resize_split:up,10
+keybind = resize/arrow_down=resize_split:down,10
+keybind = resize/arrow_left=resize_split:left,10
+keybind = resize/arrow_right=resize_split:right,10
+{{- end }}

--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -108,7 +108,7 @@ font-thicken = true
 font-thicken-strength = 1
 
 ## Notification
-notify-on-command-finish        = always
+notify-on-command-finish        = unfocused
 notify-on-command-finish-action = bell,notify
 notify-on-command-finish-after  = 10s
 

--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -180,7 +180,7 @@ keybind = super+9=last_tab
 #### Vim mode
 
 ##### Enter / Exit vim mode
-keybind = f12=activate_key_table:vim
+keybind = alt+v=activate_key_table:vim
 keybind = vim/escape=deactivate_key_table
 keybind = vim/q=deactivate_key_table
 keybind = vim/i=deactivate_key_table

--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -133,6 +133,11 @@ keybind = super+c=copy_to_clipboard
 keybind = super+v=paste_from_clipboard
 keybind = global:super+ctrl+enter=toggle_quick_terminal
 
+{{- if eq .chezmoi.os "darwin" }}
+keybind = super+z=undo
+keybind = super+shift+z=redo
+{{- end }}
+
 ### Font: ghostty +list-fonts
 keybind = super+0=reset_font_size
 keybind = super++=increase_font_size:1

--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -173,3 +173,40 @@ keybind = super+6=goto_tab:6
 keybind = super+7=goto_tab:7
 keybind = super+8=goto_tab:8
 keybind = super+9=last_tab
+
+### Key tables
+
+{{- if .ghostty.modes.vim.enabled }}
+#### Vim mode
+
+##### Enter / Exit vim mode
+keybind = f12=activate_key_table:vim
+keybind = vim/escape=deactivate_key_table
+keybind = vim/q=deactivate_key_table
+keybind = vim/i=deactivate_key_table
+keybind = vim/catch_all=ignore
+
+##### Scroll
+keybind = vim/j=scroll_page_lines:1
+keybind = vim/k=scroll_page_lines:-1
+keybind = vim/ctrl+b=scroll_page_up
+keybind = vim/ctrl+f=scroll_page_down
+
+##### Jump
+keybind = vim/g>g=scroll_to_top
+keybind = vim/shift+g=scroll_to_bottom
+
+##### Search
+keybind = vim/slash=start_search
+keybind = vim/escape=end_search
+keybind = vim/n=navigate_search:next
+keybind = vim/shift+n=navigate_search:previous
+
+##### Copy mode / selection
+# TODO: missing many functions to make this feature fully works
+keybind = vim/y=copy_to_clipboard
+keybind = vim/v=copy_to_clipboard
+
+##### Command Palette
+keybind = vim/shift+semicolon=toggle_command_palette
+{{- end }}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add macOS-specific undo/redo keybindings to Ghostty
- Implement a Vim-style navigation mode using Ghostty key tables
- Add a dedicated split resizing mode for improved window management
- Optimize command finish notification behavior and timeouts
- Update Vim mode activation shortcut for better ergonomics

#### 🎉 New Features

<details>
<summary>feat(ghostty): add resize mode key table (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/0b00df6b28e1895bdb22d87ca18d967731472a5c">0b00df6b</a>)</summary>

- Implement split resize mode activated via super+r
- Map arrow keys to resize splits by 10 pixels in respective directions
- Enable resize mode in ghostty data configuration
- Add ignore rule for catch_all in resize mode to prevent unintended actions
</details>

<details>
<summary>feat(ghostty): add vim-style key table mode (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/78509bc4ba3b6ebbf44274a31a4cecac268063eb">78509bc4</a>)</summary>

- Implement vim-style navigation mode using ghostty key tables
- Add keybindings for scrolling, jumping, searching, and copying in vim mode
- Enable vim mode by default in ghostty data configuration
- Support entering vim mode with F12 and exiting with escape, q, or i
</details>

<details>
<summary>feat(ghostty): add undo and redo keybindings for macOS (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/3b0a76f361eb299eb410b22d04e22cca85711947">3b0a76f3</a>)</summary>

- Add super+z for undo operation
- Add super+shift+z for redo operation
- Scope bindings to darwin (macOS) using chezmoi templates
</details>

#### Other Changes

<details>
<summary>refactor(ghostty): change vim mode activation key (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/996f7f213f724f7166e565d1fa9b972f702933b4">996f7f21</a>)</summary>

- Change activation shortcut from F12 to alt+v
- Update key table trigger for better ergonomics
</details>

<details>
<summary>chore(ghostty): adjust notification timeout (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/c318a73af6a90c0cae7f9ffde7fafb15d538ba70">c318a73a</a>)</summary>

- Set command finish notification delay to 30 seconds
- Reduce noise for tasks finishing within short intervals
</details>

<details>
<summary>style(ghostty): update notification behavior for finished commands (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/719b08ce27cea24e18462a2625776ea6fa3f2dd0">719b08ce</a>)</summary>

- Change notify-on-command-finish from 'always' to 'unfocused'
- Reduce notification noise by only alerting when the terminal is not active
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1589

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
