### PR TITLE
feat: Update NeoVim keymap config

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -57,8 +57,9 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
     -- Defer to ensure overriding default keymaps
     vim.schedule(function()
       require("which-key").add({
-        { "jj", "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
-        { "kk", "<C-\\><C-n>", mode = { "t" }, icon = "󰈆 ", desc = " Exit Terminal", buffer = ev.buf },
+        { "jj", "<C-\\><C-n>",       mode = "t", icon = "󰈆 ", desc = " Exit Terminal",  buffer = ev.buf },
+        { "kk", "<C-\\><C-n>",       mode = "t", icon = "󰈆 ", desc = " Exit Terminal",  buffer = ev.buf },
+        { "kj", "<C-\\><C-n><C-w>h", mode = "t", icon = " ", desc = " Move to editor", buffer = ev.buf },
       })
     end)
   end,

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -395,7 +395,7 @@ if not is_vscode then
 
     -- CLI
     { "<Leader>ap", "<CMD>Sidekick cli prompt<CR>",             icon = "󰞷 ", desc = " Prompt Menu" },
-    { "<C-.>",      "<CMD>Sidekick cli toggle<CR>", mode = nxo, icon = "󰽎 ", desc = " Switch Focus" },
+    { "<C-.>",      "<CMD>Sidekick cli focus<CR>", mode = nxo, icon = "󰽎 ", desc = " Switch Focus" },
 
     { "<Leader>at", "<CMD>Sidekick cli send msg='{this}'<CR>",       mode = nx,icon = "󰞷 ",desc = " Send Line" },
     { "<Leader>av", "<CMD>Sidekick cli send msg='{selection}'<CR>",  mode = nx,icon = "󰞷 ",desc = " Send Selection" },

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -410,6 +410,7 @@ if not is_vscode then
     mode = "n",
     { "-",         "<CMD>Oil<CR>", icon = " ", desc = " Open Parent Dir" },
     { "<Leader>e", "<CMD>Oil<CR>", icon = " ", desc = " Open Parent Dir" },
+    { "<Leader>E", "<CMD>lua require'oil'.open(Snacks.git.get_root())<CR>", icon = " ", desc = " Open Repo Root" },
   }, opts)
 end
 

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -72,7 +72,7 @@ wk.add({
   { "gl",        "<CMD>FlashJumpLine<CR>",  mode = nxo, icon = " ", desc = " Jump to the line" },
   { "gw",        "<CMD>FlashJumpWord<CR>",  mode = nxo ,icon = " ", desc = " Jump to the word" },
   { "<Leader>*", "<CMD>FlashJumpCword<CR>", mode = nxo, icon = "󰀬 ", desc = " Jump to <cword>" },
-  { "<Leader>.", "<CMD>FlashJumpContinue<CR>",          icon = " ", desc = " Coninue last search" },
+  { "<Leader>.", "<CMD>FlashJumpContinue<CR>",          icon = " ", desc = " Continue last search" },
 }, opts)
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -56,7 +56,6 @@ wk.add({
 ---------------------------------------------------------------------------
 -- Cursor
 ---------------------------------------------------------------------------
-local flash = require("flash")
 wk.add({
   { "jj", "<ESC>", mode = "i", icon = " ", desc = " Return to NORMAL mode" },
   { "kk", "<ESC>", mode = "i", icon = " ", desc = " Return to NORMAL mode" },
@@ -64,11 +63,11 @@ wk.add({
   { "[[", "<CMD>lua Snacks.words.jump(-vim.v.count1)<CR>", icon = "󰼨 ", desc = "Prev Reference" },
   { "]]", "<CMD>lua Snacks.words.jump(vim.v.count1)<CR>",  icon = "󰼧 ", desc = "Next Reference" },
 
-  { "s",     function() flash.jump() end,              mode = nxo, icon = " ", desc = " Jump" },
-  { "S",     function() flash.treesitter() end,        mode = nxo, icon = " ", desc = " Treesitter" },
-  { "r",     function() flash.remote() end,            mode = o,   icon = " ", desc = " Remote" },
-  { "R",     function() flash.treesitter_search() end, mode = ox,  icon = " ", desc = " Treesitter Search" },
-  { "<C-s>", function() flash.toggle() end,            mode = c,   icon = " ", desc = " Toggle Search" },
+  { "s",     "<CMD>lua require'flash'.jump()<CR>",              mode = nxo, icon = " ", desc = " Jump" },
+  { "S",     "<CMD>lua require'flash'.treesitter()<CR>",        mode = nxo, icon = " ", desc = " Treesitter" },
+  { "r",     "<CMD>lua require'flash'.remote()<CR>",            mode = o,   icon = " ", desc = " Remote" },
+  { "R",     "<CMD>lua require'flash'.treesitter_search()<CR>", mode = ox,  icon = " ", desc = " Treesitter Search" },
+  { "<C-s>", "<CMD>lua require'flash'.toggle()<CR>",            mode = c,   icon = " ", desc = " Toggle" },
 
   { "gl",        "<CMD>FlashJumpLine<CR>",  mode = nxo, icon = " ", desc = " Jump to the line" },
   { "gw",        "<CMD>FlashJumpWord<CR>",  mode = nxo ,icon = " ", desc = " Jump to the word" },

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -309,7 +309,9 @@ wk.add({
   { "<Leader>L",  "<CMD>Lazy<CR>",  icon = " ", desc = " lazy.nvim" },
 
   { "<Leader>l", group = "LSP", icon = "🚦 " },
-  { "<Leader>li", "<CMD>lua Snacks.picker.lsp_config()<CR>", icon = " ", desc = " Display LSP Info" },
+  { "<Leader>li", "<CMD>lua Snacks.picker.lsp_config()<CR>",           icon = " ", desc = " Display LSP Info" },
+  { "<Leader>lD", "<CMD>lua Snacks.toggle.diagnostics():toggle()<CR>", icon = " ", desc = " Diagnostics" },
+  { "gh",         "<CMD>lua Snacks.toggle.inlay_hints():toggle()<CR>", icon = " ", desc = " Inlay Hints" },
 
   { "gci", "<CMD>lua vim.lsp.buf.incoming_calls()<CR>",  icon = " ", desc = " Call incoming hierarchy" },
   { "gco", "<CMD>lua vim.lsp.buf.outcoming_calls()<CR>", icon = " ", desc = " Call outcoming hierarchy" },
@@ -454,17 +456,10 @@ if not is_vscode then
   wk.add({
     { "J",  "<CMD>TSJToggle<CR>",          icon = " ", desc = " Toggle split/join" },
 
-    -- Snacks focus modes:
-    { "\\", group = "Toggle keymaps", icon = "🎚️ " },
-    { "\\d", "<CMD>lua Snacks.toggle.dim():toggle()<CR>",  icon = " ", desc = " Dim Mode" },
-    { "\\z", "<CMD>lua Snacks.toggle.zen():toggle()<CR>",  icon = " ", desc = " Zen Mode" },
-    { "\\f", "<CMD>lua Snacks.toggle.zoom():toggle()<CR>", icon = " ", desc = " Zoom Mode" },
-
-    { "\\/", "<CMD>HlSearchLensToggle<CR>",                       icon = " ", desc = " Hlsearch lens" },
-    { "\\c", "<CMD>ColorizerToggle<CR>",                          icon = " ", desc = " Colorizer" },
-    { "\\D", "<CMD>lua Snacks.toggle.diagnostics():toggle()<CR>", icon = " ", desc = " Diagnostics" },
-    { "\\h", "<CMD>lua Snacks.toggle.inlay_hints():toggle()<CR>", icon = " ", desc = " Inlay Hints" },
-    { "\\i", "<CMD>lua Snacks.toggle.indent():toggle()<CR>",      icon = " ", desc = " Indent" },
-    { "\\t", "<CMD>lua Snacks.terminal()<CR>",         mode = nt, icon = " ", desc = " Terminal" },
+    { "<Leader>'", "<CMD>lua Snacks.toggle.dim():toggle()<CR>", icon = " ", desc = " Dim Mode" },
+    { "<Leader>z", "<CMD>lua Snacks.toggle.zen():toggle()<CR>", icon = " ", desc = " Zen Mode" },
+    { "<Leader>/", "<CMD>HlSearchLensToggle<CR>",               icon = " ", desc = " Hlsearch lens" },
+    { "<Leader>c", "<CMD>ColorizerToggle<CR>",                  icon = " ", desc = " Colorizer" },
+    { "<C-t>",     "<CMD>lua Snacks.terminal()<CR>", mode = nt, icon = " ", desc = " Terminal" },
   }, opts)
 end

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -408,8 +408,8 @@ end
 if not is_vscode then
   wk.add({
     mode = "n",
-    { "-", "<CMD>Oil<CR>", icon = " ", desc = " Open Parent Dir" },
-    -- { "<Leader>e", "<CMD>Oil<CR>", icon = " ", desc = " Open Parent Dir" },
+    { "-",         "<CMD>Oil<CR>", icon = " ", desc = " Open Parent Dir" },
+    { "<Leader>e", "<CMD>Oil<CR>", icon = " ", desc = " Open Parent Dir" },
   }, opts)
 end
 

--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -27,7 +27,6 @@ return {
   {
     "folke/flash.nvim",
     cond   = not vim.g.vscode,
-    event  = { "BufReadPost", "BufNewFile" },
     init   = function() require("ui.flash") end,
     config = function() require("user.flash") end,
   },

--- a/home/dot_config/nvim/lua/user/flash.lua
+++ b/home/dot_config/nvim/lua/user/flash.lua
@@ -21,7 +21,7 @@ flash.setup({
   continue  = false,
 
   modes = {
-    char = { autohide = true, jump_labels = true },
+    char = { autohide = true, jump_labels = false },
     treesitter = { labels = "hjklasdfgyuiopqwertnmzxcvb" },
   },
   prompt = {},


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Added terminal escape with window navigation using `kj`.
- Updated keymaps and Snacks toggles, migrating from `\` to `<Leader>`.
- Disabled jump labels for flash character mode to reduce visual noise.
- Improved loading efficiency for flash.nvim by removing redundant events and using lazy requires.
- Added keymaps (`<Leader>e`, `<Leader>E`) to open the parent directory or repository root using Oil.
- Fixed a style typo.

#### 🎉 New Features

<details>
<summary>feat(nvim): add terminal escape with window navigation (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/580c937066405b87c2f9d7ba2f0e3b40d544c71f">580c937</a>)</summary>

- Implement kj mapping in terminal mode to exit and return to the editor while keeping the Sidekick window open
- Refactor existing jj and kk escape sequences for cleaner definition
- Update terminal keymap icons and descriptions for improved visual clarity
</details>

<details>
<summary>feat(nvim): update keymaps and Snacks toggles (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/dc0165b2c98934f7da324e0cf6c54cfefad05615">dc0165b</a>)</summary>

- Add diagnostics and inlay hints toggles to LSP group
- Migrate toggle mappings from '\' prefix to <Leader>
- Update terminal mapping to <C-t> for quicker access
- Remove dedicated 'Toggle keymaps' group to simplify configuration
</details>

<details>
<summary>feat(nvim): disable jump labels for flash char mode (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/97cd63e80d997d373987a6d36125b9baa2a01b07">97cd63e</a>)</summary>

- Set jump_labels to false for character search mode in flash.nvim
- Reduce visual noise during single-character navigation
- Keep autohide enabled for the character mode search
</details>

<details>
<summary>feat(nvim): add mapping to open repo root with oil (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/33a1d7baa1aa766414b5578c31aada9d5d933768">33a1d7b</a>)</summary>

- Introduce <Leader>E mapping to open the parent directory of the repository root
- Utilize Snacks.git.get_root() to dynamically determine the project root path
- Include a specific icon and clear description for the new key mapping
</details>

<details>
<summary>feat(nvim): add leader e keymap for oil (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7ebd4cebab9b3b89936369d64f1a919dadedf8c8">7ebd4ce</a>)</summary>

- Enable <Leader>e shortcut to open parent directory using Oil
- Reformat and align existing Oil keybindings for better readability
</details>

#### Other Changes

<details>
<summary>refactor(nvim): remove explicit load events for flash.nvim (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/dc1ccd0c7fea9a689fef7fe6cc22355962dbba69">dc1ccd0</a>)</summary>

- Remove redundant BufReadPost and BufNewFile events from flash.nvim config
- Allow the plugin to be loaded more efficiently through its own triggers
- Simplify the lazy-loading configuration for better maintainability
</details>

<details>
<summary>style: fix typo (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/fa6fcffbd0871d292385f7cbab4a6dcb3bd41fed">fa6fcff</a>)</summary>

- style: fix typo
</details>

<details>
<summary>refactor(nvim): use lazy require for flash keymaps (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/c218bede78d6cc2ac5cd4e06d23a37dac2ab2287">c218bed</a>)</summary>

- Remove top-level flash module requirement to improve startup time
- Update flash keybindings to use inline require calls in commands
- Simplify the description for the flash search toggle keymap
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1602

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
