### PR TITLE
feat: Add OpenCode model fallbacks

### DIFF
--- a/home/.chezmoidata/opencode.toml
+++ b/home/.chezmoidata/opencode.toml
@@ -12,12 +12,38 @@ instructions = [ "AGENTS.md", "CONTRIBUTING.md" ]
 enabled_providers = [ "opencode", "openrouter", "github-copilot", "ollama" ]
 
 [opencode.models]
-sota    = "opencode/big-pickle"
-elite   = "opencode/big-pickle"
-general = "opencode/big-pickle"
-lite    = "openocde/big-pickle"
-# general = "google/gemini-3-pro-preview"
-# lite    = "google/gemini-3-flash-preview"
+ultra   = [
+  "opencode/glm-5-free",
+  "ollama/glm-5:cloud",
+  "ollama/minimax-m2.7:cloud",
+  "opencode/kimi-k2.5-free",
+  "ollama/kimi-k2.5:cloud",
+  "opencode/big-pickle"
+]
+elite   = [
+  "opencode/kimi-k2.5-free",
+  "opencode/glm-4.7-free",
+  "ollama/kimi-k2.5:cloud",
+  "opencode/big-pickle",
+  "opencode/minimax-m2.5-free",
+  "opencode/nemotron-3-super-free",
+]
+general = [
+  "opencode/glm-4.7-free",
+  "opencode/big-pickle",
+  "opencode/minimax-m2.5-free",
+  "openrouter/nvidia/nemotron-3-super-120b-a12b:free",
+]
+lite    = [
+  "opencode/minimax-m2.5-free",
+  "opencode/nemotron-3-super-free",
+  "openrouter/nvidia/nemotron-3-super-120b-a12b:free",
+]
+micro   = [
+  "openrouter/z-ai/glm-4.5-air:free",
+  "openrouter/nvidia/nemotron-3-super-120b-a12b:free",
+  "opencode/nemotron-3-super-free",
+]
 
 [opencode.tui]
 scroll_speed = 2
@@ -289,7 +315,7 @@ name = "NVIDIA: Nemotron 3 Super"
 [opencode.providers.ollama]
 name    = "Ollama"
 npm     = "@ai-sdk/openai-compatible"
-whitelist = ["qwen3.5:cloud", "kimi-k2.5:cloud", "glm-5:cloud"]
+whitelist = ["glm-5:cloud", "minimax-m2.7:cloud", "kimi-k2.5:cloud", "qwen3.5:cloud"]
 options = { baseURL = "https://ollama.com/v1" }
 
 [opencode.providers.ollama.models."qwen3.5:cloud"]
@@ -300,6 +326,10 @@ name = "Kimi K2.5 (cloud)"
 
 [opencode.providers.ollama.models."glm-5:cloud"]
 name = "GLM 5 (cloud)"
+
+[opencode.providers.ollama.models."minimax-m2.7:cloud"]
+name = "Minimax-m2.7 (cloud)"
+
 
 ## GitHub Copilot
 [opencode.providers.github-copilot]

--- a/home/.chezmoidata/opencode.toml
+++ b/home/.chezmoidata/opencode.toml
@@ -267,7 +267,7 @@ account_selection_strategy = "hybrid" # "sticky"|"round-robin"|"hybrid"
 ## Opencode Zen
 [opencode.providers.opencode]
 options   = { baseUrl = "https://opencode.ai/zen/v1", apiKey = "{env:OPENCODE_API_KEY}" }
-whitelist = ["kimi-k2.5-free", "big-pickle", "minimax-m2.5-free", "nemotron-3-super-free"]
+whitelist = ["kimi-k2.5-free", "glm-5-free", "glm-4.7-free", "big-pickle", "minimax-m2.5-free", "nemotron-3-super-free"]
 
 ## OpenRouter
 [opencode.providers.openrouter]

--- a/home/dot_config/opencode/oh-my-opencode.json.tmpl
+++ b/home/dot_config/opencode/oh-my-opencode.json.tmpl
@@ -6,50 +6,109 @@
     "commit_footer": false,
     "include_co_authored_by": false
   },
+  "runtime_fallback": {
+    "enabled": true,
+    "max_fallback_attempts": 3,
+    "notify_on_fallback": true
+  },
   "agents": {
     {{/*********** Core Agents ***********/ -}}
     {{/* The default orchestrator. Plans, delegates, and executes complex tasks using specialized subagents with aggressive parallel execution. Todo-driven workflow with extended thinking (32k budget). */ -}}
-    "sisyphus":          { "model": {{ .opencode.models.sota | quote }} },
+    "sisyphus": {
+      "model": {{ index .opencode.models.ultra 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.ultra 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* The Legitimate Craftsman. Autonomous deep worker inspired by AmpCode's deep mode. Goal-oriented execution with thorough research before action. Explores codebase patterns, completes tasks end-to-end without premature stopping. Named after the Greek god of forge and craftsmanship. */ -}}
-    "hephaestus":        { "model": {{ .opencode.models.elite | quote }} },
+    "hephaestus": {
+      "model": {{ index .opencode.models.elite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.elite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Architecture decisions, code review, debugging. Read-only consultation - stellar logical reasoning and deep analysis. Inspired by AmpCode. */ -}}
-    "oracle":            { "model": {{ .opencode.models.elite | quote }} },
+    "oracle": {
+      "model": {{ index .opencode.models.elite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.elite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Multi-repo analysis, documentation lookup, OSS implementation examples. Deep codebase understanding with evidence-based answers. Inspired by AmpCode. */ -}}
-    "librarian":         { "model": {{ .opencode.models.lite | quote }} },
+    "librarian": {
+      "model": {{ index .opencode.models.lite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.lite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Fast codebase exploration and contextual grep. Uses Gemini 3 Flash when Antigravity auth is configured, Haiku when Claude max20 is available, otherwise Grok. Inspired by Claude Code. */ -}}
-    "explore":           { "model": {{ .opencode.models.lite | quote }} },
+    "explore": {
+      "model": {{ index .opencode.models.lite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.lite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Visual content specialist. Analyzes PDFs, images, diagrams to extract information. Saves tokens by having another agent process media. */ -}}
-    "multimodal-looker": { "model": {{ .opencode.models.lite | quote }} },
+    "multimodal-looker": {
+      "model": {{ index .opencode.models.lite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.lite 1 | toPrettyJson | indent 6 | trim }}
+    },
 
     {{/*********** Plan Agents ***********/ -}}
     {{/* Strategic planner with interview mode. Creates detailed work plans through iterative questioning. */ -}}
-    "prometheus": { "model": {{ .opencode.models.sota | quote }} },
+    "prometheus": {
+      "model": {{ index .opencode.models.ultra 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.ultra 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Plan consultant - pre-planning analysis. Identifies hidden intentions, ambiguities, and AI failure points. */ -}}
-    "metis":      { "model": {{ .opencode.models.elite | quote }} },
+    "metis": {
+      "model": {{ index .opencode.models.elite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.elite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Plan reviewer - validates plans against clarity, verifiability, and completeness standards. */ -}}
-    "momus":      { "model": {{ .opencode.models.elite | quote }} },
+    "momus": {
+      "model": {{ index .opencode.models.elite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.elite 1 | toPrettyJson | indent 6 | trim }}
+    },
 
     {{/*********** Orchestration Agents ***********/ -}}
     {{/* Todo-list orchestrator. Executes planned tasks systematically, managing todo items and coordinating work. */ -}}
-    "atlas":      { "model": {{ .opencode.models.elite | quote }} },
+    "atlas": {
+      "model": {{ index .opencode.models.elite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.elite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/*  Category-spawned executor. Model is selected automatically based on the task category (visual-engineering, quick, deep, etc.). Used when the main agent delegates work via the task tool. */ -}}
-    "sisyphus-junior":   { "model": {{ .opencode.models.elite | quote }} }
+    "sisyphus-junior": {
+      "model": {{ index .opencode.models.elite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.elite 1 | toPrettyJson | indent 6 | trim }}
+      }
   },
   "categories": {
     {{/* Frontend, UI/UX, design, styling, animation */ -}}
-    "visual-engineering": { "model": {{ .opencode.models.general | quote }} },
+    "visual-engineering": {
+      "model": {{ index .opencode.models.general 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.general 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Deep logical reasoning, complex architecture decisions requiring extensive analysis */ -}}
-    "ultrabrain":         { "model": {{ .opencode.models.sota | quote }} },
+    "ultrabrain": {
+      "model": {{ index .opencode.models.ultra 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.ultra 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Highly creative/artistic tasks, novel ideas */ -}}
-    "artistry":           { "model": {{ .opencode.models.general | quote }} },
+    "artistry": {
+      "model": {{ index .opencode.models.general 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.general 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Trivial tasks - single file changes, typo fixes, simple modifications */ -}}
-    "quick":              { "model": {{ .opencode.models.lite | quote }} },
+    "quick": {
+      "model": {{ index .opencode.models.lite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.lite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Tasks that don't fit other categories, low effort required */ -}}
-    "unspecified-low":    { "model": {{ .opencode.models.elite | quote }} },
+    "unspecified-low": {
+      "model": {{ index .opencode.models.elite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.elite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Tasks that don't fit other categories, high effort required */ -}}
-    "unspecified-high":   { "model": {{ .opencode.models.elite | quote }} },
+    "unspecified-high": {
+      "model": {{ index .opencode.models.elite 0 | quote }} ,
+      "fallback_models": {{ slice .opencode.models.elite 1 | toPrettyJson | indent 6 | trim }}
+    },
     {{/* Documentation, prose, technical writing */ -}}
-    "writing":            { "model": {{ .opencode.models.lite | quote }} }
+    "writing": {
+      "model": {{ index .opencode.models.lite 0 | quote }},
+      "fallback_models": {{ slice .opencode.models.lite 1 | toPrettyJson | indent 6 | trim }}
+    }
   },
   "disabled_mcps": [],
   "disabled_skills": ["playwright"]


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Implement tiered model fallback system for AI agents
- Add support for new GLM-5, GLM-4.7, and Minimax-m2.7 models
- Enable runtime fallback mechanisms with configurable attempts and notifications

#### 🎉 New Features

<details>
<summary>feat(opencode): implement model fallback system for agents (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/8149ee97567a25fe324e876cb03b2d92028cba0c">8149ee97</a>)</summary>

- Update opencode.toml to include tiered model lists (ultra, elite, general, etc.)
- Enable runtime fallback with max attempts and notifications in agent config
- Refactor agent and category configurations to use primary and fallback models
- Add support for Minimax-m2.7 and GLM-5 cloud models via Ollama
</details>

<details>
<summary>feat(opencode): add GLM-5 and GLM-4.7 free models (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/327ce707c2103856314b26aad41796657b45bc86">327ce707</a>)</summary>

- Add glm-5-free and glm-4.7-free to the Opencode provider whitelist
- Enable access to new free GLM models in the Zen provider configuration
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1621

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
