### PR TITLE
feat: Update gh extension config

### DIFF
--- a/home/.chezmoidata/gh.toml
+++ b/home/.chezmoidata/gh.toml
@@ -2,6 +2,7 @@
 
 [extensions]
 gh = [
+  "github/gh-aw",                 # GitHub Agentic Workflows
   "seachicken/gh-poi",            # Safely clean up your local branches
   "dlvhdr/gh-dash",               # Dashboard
   "kawarimidoll/gh-graph",        # Activity graph

--- a/home/.chezmoidata/gh.toml
+++ b/home/.chezmoidata/gh.toml
@@ -3,7 +3,6 @@
 [extensions]
 gh = [
   "dlvhdr/gh-dash",               # Dashboard
-  "actions/gh-actions-cache",     # Manage GitHub Actions cache
   "kawarimidoll/gh-graph",        # Activity graph
   "meiji163/gh-notify",           # Notification Extension
   "gennaro-tedesco/gh-s",         # Search repositories interactively

--- a/home/.chezmoidata/gh.toml
+++ b/home/.chezmoidata/gh.toml
@@ -2,6 +2,7 @@
 
 [extensions]
 gh = [
+  "seachicken/gh-poi",            # Safely clean up your local branches
   "dlvhdr/gh-dash",               # Dashboard
   "kawarimidoll/gh-graph",        # Activity graph
   "meiji163/gh-notify",           # Notification Extension

--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -157,6 +157,7 @@ abbr -a -- ghg "gh graph"
 abbr -a -- ghn "gh notify"
 abbr -a -- ghs "gh s"
 abbr -a -- ghm "gh markdown-preview"
+abbr -a -- ghp "gh poi"
 
 ### mise
 abbr -a -- m  "mise"

--- a/home/dot_config/zsh/abbreviations
+++ b/home/dot_config/zsh/abbreviations
@@ -94,6 +94,7 @@ abbr ghg="gh graph"
 abbr ghn="gh notify"
 abbr ghs="gh s"
 abbr ghm="gh markdown-preview"
+abbr ghp="gh poi"
 
 # mise
 abbr m="mise"


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add `github/gh-aw` (GitHub Agentic Workflows) extension to GitHub CLI configuration.
- Add `seachicken/gh-poi` (local branch cleanup) extension to GitHub CLI configuration.
- Add `ghp` abbreviation for `gh poi` to Fish and Zsh configurations.
- Remove `actions/gh-actions-cache` extension from GitHub CLI configuration.

#### 🎉 New Features

<details>
<summary>feat(gh): add gh-aw extension (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/9085becfcb12b7f4d48fe2e1d8340ab318b7cd70">9085bec</a>)</summary>

- Add github/gh-aw to the GitHub CLI extensions list in Chezmoi data
</details>

<details>
<summary>feat(shell): add ghp abbreviation for gh poi (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/12aaa1ede130a0707428a3a31d6c6fe5b97b254a">12aaa1e</a>)</summary>

- Add ghp alias to Fish and Zsh configurations
</details>

<details>
<summary>feat(gh): add gh-poi extension (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/8c05f006fba159f57afd80719f79e3fffad11e37">8c05f00</a>)</summary>

- Add seachicken/gh-poi to the GitHub CLI extensions list in Chezmoi data
</details>

<details>
<summary>feat(gh): remove gh-actions-cache extension (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7f3869526fe1fdae12ffc0776f47a9eb4f10badc">7f38695</a>)</summary>

- Remove actions/gh-actions-cache from the GitHub CLI extensions list in Chezmoi data
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1626

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
