### PR TITLE
feat(nvim): Update snacks config

### DIFF
--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -189,7 +189,6 @@ if not is_vscode then
     { "<Leader>f", group = "Fuzzy Finder", icon = "🔎 " },
 
     -- Builtin
-    { "<Leader>fe", "<CMD>lua Snacks.explorer()<CR>",        icon = " ", desc = " File Explorer"},
     { "<Leader>ff", "<CMD>lua Snacks.picker.smart()<CR>",    icon = " ", desc = " Smart Find Files" },
     { "<Leader>f.", "<CMD>lua Snacks.picker.resume()<CR>",   icon = " ", desc = " Resume Prev Picker" },
     { "<Leader>fk", "<CMD>lua Snacks.picker.keymaps()<CR>",  icon = " ", desc = " Keymaps" },

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -196,7 +196,7 @@ if not is_vscode then
     { "<Leader>fc", "<CMD>lua Snacks.picker.commands()<CR>", icon = " ", desc = " Commands" },
     { "<Leader>fp", "<CMD>lua Snacks.picker.projects()<CR>", icon = " ", desc = " Project" },
     {
-      "<Leader>fF",
+      "<Leader>F",
       "<CMD>lua Snacks.picker.smart({ cwd = vim.fn.expand('%:p:h') })<CR>",
       icon = " ",
       desc = " Browse Current Dir",

--- a/home/dot_config/nvim/lua/user/snacks/explorer.lua
+++ b/home/dot_config/nvim/lua/user/snacks/explorer.lua
@@ -2,6 +2,6 @@
 
 ---@class snacks.explorer.Config
 return {
-  enabled = true,
+  enabled = false,
   replace_netrw = true,
 }

--- a/home/dot_config/nvim/lua/user/snacks/input.lua
+++ b/home/dot_config/nvim/lua/user/snacks/input.lua
@@ -2,12 +2,6 @@
 
 ---@class snacks.input.Config
 return {
-  enable     = true,
-
-  icon       = " ",
-  icon_hl    = "SnacksInputIcon",
-  icon_pos   = "left",
-  prompt_pos = "title",
-  win        = { style = "input" },
-  expand     = true,
+  enable = true,
+  expand = true,
 }

--- a/home/dot_config/nvim/lua/user/snacks/picker/git_log.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/git_log.lua
@@ -1,0 +1,4 @@
+---@type snacks.picker.Config
+return {
+  focus = "list",
+}

--- a/home/dot_config/nvim/lua/user/snacks/picker/init.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/init.lua
@@ -25,6 +25,14 @@ return {
     },
   },
 
+  ---@class snacks.picker.layout.Config
+  layout = {
+    layout = {
+      width = 0.85,
+      height = 0.9,
+    },
+  },
+
   sort = {
     -- default sort is by score, text length and index
     fields = { "score:desc", "#text", "idx" },

--- a/home/dot_config/nvim/lua/user/snacks/picker/init.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/init.lua
@@ -45,6 +45,7 @@ return {
     snippets   = require("user.snacks.picker.snippets"),
     git_status = require("user.snacks.picker.git_status"),
     git_diff   = require("user.snacks.picker.git_diff"),
+    git_log    = require("user.snacks.picker.git_log"),
     gh_issue   = {},
     gh_pr      = {},
   },

--- a/home/dot_config/nvim/lua/user/snacks/scope.lua
+++ b/home/dot_config/nvim/lua/user/snacks/scope.lua
@@ -1,11 +1,4 @@
 -- -*-mode:lua-*- vim:ft=lua
-local scope = require("snacks.scope")
-
-require("which-key").add({
-  mode = { "n", "x", "o" },
-  { "[i", function() scope.jump({ min_size = 1, bottom = false }) end, icon = " ", desc = "Scope Top" },
-  { "]i", function() scope.jump({ min_size = 1, bottom = true })  end, icon = " ", desc = "Scope Bottom" },
-})
 
 ---@type snacks.scope.Config
 return {

--- a/home/dot_config/nvim/lua/user/snacks/statuscolumn.lua
+++ b/home/dot_config/nvim/lua/user/snacks/statuscolumn.lua
@@ -2,7 +2,7 @@
 
 ---@type snacks.statuscolumn.Config
 return {
-  enabled     = true,
+  enabled = false,
   left  = { "mark", "sign" },
   right = { "fold", "git" },
 }


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Added git_log picker configuration and layout settings for Snacks picker.
- Simplified snacks input and scope configurations.
- Disabled snacks statuscolumn and explorer modules.
- Updated browse directory keybinding to <Leader>F.

#### 🎉 New Features

<details>
<summary>feat(nvim): add git_log picker configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/376a4e3f">376a4e3f</a>)</summary>

- Implement new git_log picker configuration for Snacks with focus set to list
- Update snacks picker initialization to include the new git_log module
</details>

<details>
<summary>feat(nvim): disable snacks statuscolumn (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/4e096a7f">4e096a7f</a>)</summary>

- Set enabled to false in snacks statuscolumn configuration
- Turn off the custom status column component in snacks.nvim
</details>

<details>
<summary>feat(nvim): add layout configuration to snacks picker (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/1b720258">1b720258</a>)</summary>

- Set default picker width to 85 0x0p+0nd height to 90%
- Add type annotation for snacks picker layout configuration
- Enhance visual consistency of picker windows
</details>

#### Other Changes

<details>
<summary>refactor(nvim): simplify snacks input configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7fa811ce">7fa811ce</a>)</summary>

- Remove redundant icon and prompt position settings
- Delete custom window style for input components
- Maintain expansion and enabled status while using defaults
</details>

<details>
<summary>refactor(nvim): simplify snacks scope configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/47ce9838">47ce9838</a>)</summary>

- Remove redundant which-key keymap registrations for scope jumps
- Delete unused local scope variable import
- Clean up file structure to focus on providing configuration only
</details>

<details>
<summary>refactor(nvim): update browse directory keymap to <Leader>F (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b6912a99">b6912a99</a>)</summary>

- Change keybinding for browsing current directory from <Leader>fF to <Leader>F
- Optimize access to directory-scoped smart picker for faster navigation
</details>

<details>
<summary>chore(nvim): disable snacks explorer and remove keymap (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/a6fbe534">a6fbe534</a>)</summary>

- Disable Snacks explorer module in configuration
- Remove leader-f-e keybinding for file explorer
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1648

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
