### PR TITLE
feat: Update nvim autocmds

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -65,6 +65,16 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
   end,
 })
 
+-- Restore cursor to file position in previous editing session
+vim.api.nvim_create_autocmd({ "BufReadPost" }, {
+  callback = function(ev)
+    local mark = vim.api.nvim_buf_get_mark(ev.buf, '"')
+    if mark[1] > 0 and mark[1] <= vim.api.nvim_buf_line_count(ev.buf) then
+      vim.cmd('normal! g`"zz')
+    end
+  end,
+})
+
 local cursor_grp = augroup("CustomCursor")
 -- Enable cursorcolumn automatically
 vim.api.nvim_create_autocmd({ "BufEnter", "FocusGained", "InsertLeave", "CmdlineLeave", "WinEnter" }, {

--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -42,7 +42,7 @@ vim.api.nvim_create_autocmd("TextYankPost", {
 -- Close specific filetype with <q>
 vim.api.nvim_create_autocmd("FileType", {
   group    = augroup("CustomClose"),
-  pattern  = { "help", "man", "qf", "lspinfo", "notify", "oil", "dap-view", "dap-view-term", "dap-view-repl" },
+  pattern  = { "help", "man", "qf", "lspinfo", "notify", "trouble", "dap-view", "dap-view-term", "dap-view-repl" },
   callback = function (ev)
     vim.bo[ev.buf].buflisted = false
     vim.keymap.set("n", "q", "<CMD>close<CR>", { buffer = ev.buf, silent = true })


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add NeoVim autocmd to restore cursor position on file open
- Update NeoVim CustomClose autocmd with new filetypes

#### 🎉 New Features

<details>
<summary>feat(nvim): add autocmd to restore cursor position (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/17f1ba12d6d354b936a37f181eb904ec65d1c2cf">17f1ba1</a>)</summary>

- Implement BufReadPost autocmd to jump to last known position
- Verify mark validity within current buffer line count
- Center view using zz after jumping to the position
</details>

<details>
<summary>feat(nvim): update filetypes for CustomClose autocmd (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/d61ca702344f1037fa6cb2ffa8b0feb0589d53e7">d61ca70</a>)</summary>

- Add trouble to the list of filetypes that close with q
- Remove oil from the pattern in the CustomClose group
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1655

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
