### PR TITLE
feat: Refine nvim comment config

### DIFF
--- a/home/dot_config/nvim/lua/plugins/treesitter.lua
+++ b/home/dot_config/nvim/lua/plugins/treesitter.lua
@@ -31,7 +31,7 @@ return {
   { "windwp/nvim-ts-autotag", ft = ft.autotag, config = function() require("user.treesitter.autotag") end },
   { "andymass/vim-matchup",   ft = ft.matchup, config = function() require("user.treesitter.matchup") end },
   {
-    "numToStr/Comment.nvim",
+    "nvim-mini/mini.comment",
     event  = { "BufReadPost", "BufNewFile" },
     config = function() require("user.treesitter.comment") end,
   },

--- a/home/dot_config/nvim/lua/user/treesitter/comment.lua
+++ b/home/dot_config/nvim/lua/user/treesitter/comment.lua
@@ -1,25 +1,34 @@
-local ok, comment = pcall(require, "Comment")
+local ok, comment = pcall(require, "mini.comment")
 if not ok then return end
 
--- to skip backwards compatibility routines and speed up loading
-vim.g.skip_ts_context_commentstring_module = true
-
-comment.setup({
-  padding   = true,
-  sticky    = true,
-  ignore    = "^$",
-
-  toggler   = { line = "gcc", block = "gbc" },
-  opleader  = { line = "gc", block = "gb" },
-  extra     = { above = "gcO", below = "gco", eol = "gcA" },
-  mappings  = { basic = true, extra = true },
-
-  pre_hook  = require('ts_context_commentstring.integrations.comment_nvim').create_pre_hook(),
-  post_hook = function() end,
+local commentstring = require("ts_context_commentstring")
+commentstring.setup({
+  enable_autocmd = false,
 })
 
--- Workaround overlapping with `gb` & `gc`: numToStr/Comment.nvim#483
-vim.keymap.del("n", "gb")
+comment.setup({
+  options = {
+    -- Function to compute custom 'commentstring' (optional)
+    custom_commentstring = function()
+      return commentstring.calculate_commentstring() or vim.bo.commentstring
+    end,
+    ignore_blank_line    = false, -- Whether to ignore blank lines when commenting
+    start_of_line        = false, -- Whether to ignore blank lines in actions and textobject
+    pad_comment_parts    = true,  -- Whether to force single space inner padding for comment parts
+  },
+  mappings = {
+    comment        = "gc",  -- Normal and Visual modes
+    comment_line   = "gcc", -- Toggle comment on current line
+    comment_visual = "gc",  -- Toggle comment on visual selection
+    textobject     = "gc",  -- Define 'comment' textobject (like `dgc` - delete whole comment block)
+  },
+  hooks = {
+    pre  = function() end,
+    post = function() end,
+  },
+})
+
+-- Workaround overlapping with `gc`
 vim.keymap.del("n", "gc")
 
 require("which-key").add({


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Transitioned the commenting system from Comment.nvim to mini.comment for better integration
- Configured tree-sitter based context-aware commentstrings for mini.comment

#### 🎉 New Features

<details>
<summary>feat(nvim): migrate comment configuration to mini.comment (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/2650e4779fbaa6e51e07acdccf634792ed1e8cd3">2650e47</a>)</summary>

- Implement setup for mini.comment with custom commentstring calculation
- Integrate ts_context_commentstring for tree-sitter based commenting
- Update toggle and visual mappings to use gc/gcc patterns
- Remove redundant Comment.nvim hooks and keymap deletions
</details>

<details>
<summary>feat(nvim): switch comment plugin to mini.comment (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/f1b84cd074dba861a7170445d21263d41c02638b">f1b84cd</a>)</summary>

- Replace numToStr/Comment.nvim with nvim-mini/mini.comment
- Maintain existing configuration via user.treesitter.comment
- Improve plugin consistency by adopting mini.nvim components
</details>
## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1667

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
