### PR TITLE
feat: Add nvim linter config

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -177,6 +177,13 @@ vim.api.nvim_create_autocmd({ "LspAttach" }, {
   end
 })
 
+-- Lint on save automatically
+vim.api.nvim_create_autocmd({ "BufWritePost" }, {
+  callback = function(_)
+    require("lint").try_lint()
+  end,
+})
+
 local snip_grp = augroup("LuaSnipCustomGroup")
 local ls = require("luasnip")
 -- Disable diagnostics in snippet

--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -57,6 +57,11 @@ return {
     cmd    = { "ConformInfo" },
     config = function() require("user.formatter") end,
   },
+  {
+    "mfussenegger/nvim-lint",
+    event  = { "BufReadPost", "BufNewFile" },
+    config = function() require("user.linter") end,
+  },
   -- Tex
   {
     "lervag/vimtex",

--- a/home/dot_config/nvim/lua/user/linter.lua
+++ b/home/dot_config/nvim/lua/user/linter.lua
@@ -1,0 +1,15 @@
+local ok, lint = pcall(require, "lint")
+if not ok then return end
+
+lint.linters_by_ft = {
+  bash = { "bash" },
+  zsh  = { "zsh" },
+  fish = { "fish" },
+  make = { "checkmake" },
+  c    = { "clangd" },
+  go   = { "golangci-lint" },
+
+  ghaction   = { "actionlint" },
+  dockerfile = { "hadolint" },
+  markdown   = { "markdownlint-cli2" },
+}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add `nvim-lint` for asynchronous linting support
- Configure language-specific linters including shell, C, Go, and Markdown
- Enable automatic linting feedback upon saving files

#### 🎉 New Features

<details>
<summary>feat(nvim): trigger linting automatically on buffer write (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/c9f47e482c77eb4d4453e0105b7a566391a266cd">c9f47e48</a>)</summary>

- Add BufWritePost autocmd to execute require("lint").try_lint()
- Enable automatic linting feedback after saving files
- Ensure linting stays up-to-date without manual invocation
</details>

<details>
<summary>feat(nvim): configure linters by filetype for nvim-lint (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/24d03a8418959c1462c98910cdc732f97e4d2c6f">24d03a84</a>)</summary>

- Create user.linter module to manage linter configurations
- Define default linters for various languages including shell scripts, C, Go, and Markdown
- Add support for Actionlint and Hadolint for CI and Dockerfile validation
</details>

<details>
<summary>feat(nvim): add nvim-lint for asynchronous linting (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/572cc85c525a1eb9505a16af112c347f1ebc6664">572cc85c</a>)</summary>

- Integrate mfussenegger/nvim-lint plugin into Neovim configuration
- Set up linter configuration to be loaded from user.linter module
- Configure plugin to trigger on BufReadPost and BufNewFile events
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1673

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
