### PR TITLE
feat(nvim): add markdown picker to snacks.picker

### DIFF
--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -251,9 +251,10 @@ if not is_vscode then
     },
 
     -- LSP
-    { "<Leader>fd", "<CMD>lua Snacks.picker.diagnostics()<CR>",          icon = " ", desc = " Diagnostics" },
-    { "<Leader>fs", "<CMD>lua Snacks.picker.lsp_symbols()<CR>",          icon = " ", desc = " Symbols" },
-    { "<Leader>fr", "<CMD>lua Snacks.picker.lsp_references()<CR>",       icon = " ", desc = " References" },
+    { "<Leader>fd", "<CMD>lua Snacks.picker.diagnostics()<CR>",    icon = " ", desc = " Diagnostics" },
+    { "<Leader>fm", "<CMD>lua Snacks.picker.markdown()<CR>",       icon = " ", desc = " Documentation" },
+    { "<Leader>fs", "<CMD>lua Snacks.picker.lsp_symbols()<CR>",    icon = " ", desc = " Symbols" },
+    { "<Leader>fr", "<CMD>lua Snacks.picker.lsp_references()<CR>", icon = " ", desc = " References" },
 
     -- Others
     { "<Leader>fz", "<CMD>lua Snacks.picker.zoxide()<CR>",   icon = "󰾶 ", desc = " Zoxide" },

--- a/home/dot_config/nvim/lua/user/snacks/picker/init.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/init.lua
@@ -42,6 +42,7 @@ return {
     files = { hidden = true },
     smart = { hidden = true, filter = { cwd = true } },
     grep  = { hidden = true },
+    markdown   = require("user.snacks.picker.markdown"),
     snippets   = require("user.snacks.picker.snippets"),
     git_status = require("user.snacks.picker.git_status"),
     git_diff   = require("user.snacks.picker.git_diff"),

--- a/home/dot_config/nvim/lua/user/snacks/picker/markdown.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/markdown.lua
@@ -1,0 +1,16 @@
+-- -*-mode:lua-*- vim:ft=lua
+
+---@type snacks.picker.Config
+return {
+  finder  = "files",
+  format  = "file",
+  -- preview = "preview",
+  args    = {
+    "-e", "md",
+    "-e", "mdx",
+    "-e", "markdown",
+    "-e", "wiki",
+  },
+  -- Add a custom icon and name for the picker
+  prompt = "   ",
+}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add a dedicated markdown file picker to Neovim via `snacks.picker`

#### 🎉 New Features

<details>
<summary>feat(nvim): add markdown picker to snacks.picker (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/cd539bd8441931e45148284068f7fda0cbd827b1">cd539bd8</a>)</summary>

- Implement custom markdown picker configuration in user.snacks.picker.markdown
- Add <Leader>fm keymap to trigger the markdown picker
- Register markdown picker in the main snacks.picker initialization
- Configure the picker to find .md, .mdx, .markdown, and .wiki files
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1675

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
