### PR TITLE
feat(nvim): Add align plugin

### DIFF
--- a/home/dot_config/nvim/lua/core/autocmds.lua
+++ b/home/dot_config/nvim/lua/core/autocmds.lua
@@ -138,7 +138,7 @@ vim.api.nvim_create_autocmd({ "LspAttach" }, {
     vim.keymap.set("n", "gI",         vim.lsp.buf.implementation, extend("keep", opts, { desc = " Implementation" }))
     vim.keymap.set("n", "gn",         vim.lsp.buf.rename,         extend("keep", opts, { desc = " Rename" }))
     -- vim.keymap.set("n", "gr",         vim.lsp.buf.references,     extend("keep", opts, { desc = " References" }))
-    vim.keymap.set({"n", "v"}, "ga",  vim.lsp.buf.code_action,    extend("keep", opts, { desc = " Code Action" }))
+    vim.keymap.set({"n", "v"}, "la",  vim.lsp.buf.code_action,    extend("keep", opts, { desc = " Code Action" }))
   end
 })
 

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -33,7 +33,6 @@ wk.add({
   { "g",  group = "Go to",    icon = " ", desc = " Go to" },
   { "gs", group = "Surround", icon = "󰅪 ", desc = " Surround" },
   { "z",  group = "Fold",     icon = " ", desc = " Fold / Cursor" },
-  { "m",  group = "mini.*",   icon = " ", desc = " mini.* Plugins" },
 })
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -33,6 +33,7 @@ wk.add({
   { "g",  group = "Go to",    icon = " ", desc = " Go to" },
   { "gs", group = "Surround", icon = "󰅪 ", desc = " Surround" },
   { "z",  group = "Fold",     icon = " ", desc = " Fold / Cursor" },
+  { "m",  group = "mini.*",   icon = " ", desc = " mini.* Plugins" },
 })
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -50,6 +50,7 @@ return {
     "nvim-mini/mini.align",
     version = "*",
     event  = { "BufReadPost", "BufNewFile" },
+    config = function() require("user.align") end,
   },
   {
     "folke/trouble.nvim",

--- a/home/dot_config/nvim/lua/plugins/editor.lua
+++ b/home/dot_config/nvim/lua/plugins/editor.lua
@@ -47,6 +47,11 @@ return {
     config  = function() require("user.surround") end,
   },
   {
+    "nvim-mini/mini.align",
+    version = "*",
+    event  = { "BufReadPost", "BufNewFile" },
+  },
+  {
     "folke/trouble.nvim",
     cmd = { "Trouble" },
     config = function() require("lsp.config.trouble") end,

--- a/home/dot_config/nvim/lua/user/align.lua
+++ b/home/dot_config/nvim/lua/user/align.lua
@@ -1,0 +1,51 @@
+local ok, align = pcall(require, "mini.align")
+if not ok then return end
+
+align.setup({
+  mappings = {
+    start              = "<Leader>ma",
+    start_with_preview = "<Leader>mA",
+  },
+
+  modifiers = {
+    -- Main option modifiers
+    -- ["s"] = --<function: enter split pattern>,
+    -- ["j"] = --<function: choose justify side>,
+    -- ["m"] = --<function: enter merge delimiter>,
+
+    -- Modifiers adding pre-steps
+    -- ["f"] = --<function: filter parts by entering Lua expression>,
+    -- ["i"] = --<function: ignore some split matches>,
+    -- ["p"] = --<function: pair parts>,
+    -- ["t"] = --<function: trim parts>,
+
+    -- Delete some last pre-step
+    -- ["<BS>"] = --<function: delete some last pre-step>,
+
+    -- Special configurations for common splits
+    -- ["="] = --<function: enhanced setup for "=">,
+    -- [","] = --<function: enhanced setup for ",">,
+    -- ["|"] = --<function: enhanced setup for "|">,
+    -- [" "] = --<function: enhanced setup for " ">,
+  },
+
+  options = {
+    split_pattern = "",
+    justify_side = "left",
+    merge_delimiter = "",
+  },
+
+  steps = {
+    pre_split   = {},
+    split       = nil,
+    pre_justify = {},
+    justify     = nil,
+    pre_merge   = {},
+    merge       = nil,
+  },
+
+  -- Whether to disable showing non-error feedback
+  -- This also affects (purely informational) helper messages shown after
+  -- idle time if user input is required.
+  silent = false,
+})

--- a/home/dot_config/nvim/lua/user/align.lua
+++ b/home/dot_config/nvim/lua/user/align.lua
@@ -3,8 +3,8 @@ if not ok then return end
 
 align.setup({
   mappings = {
-    start              = "<Leader>ma",
-    start_with_preview = "<Leader>mA",
+    start              = "ga",
+    start_with_preview = "gA",
   },
 
   modifiers = {


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add `mini.align` plugin for text alignment support
- Configure `ga` and `gA` as the primary alignment trigger keys
- Move LSP code action mapping to `la` to prevent keymap conflicts

#### 🎉 New Features

<details>
<summary>feat(nvim): update alignment keymaps to ga/gA (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/0c2fd4747fe535b5a8d27b5d0b3213b9de680900">0c2fd47</a>)</summary>

- Remap mini.align start mappings to ga and gA for better ergonomics
- Move LSP code actions mapping from ga to la to prevent conflict
- Remove the temporary "mini.*" keymap group from core configuration
</details>

<details>
<summary>feat(nvim): configure mini.align and setup keymaps (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/5e5e3db6f85e945ba67d6ef117dfa1d4d786d5ac">5e5e3db</a>)</summary>

- Create lua/user/align.lua with detailed plugin configuration
- Register "m" (mini.*) group and alignment keymaps in keymap.lua
- Update editor plugin config to initialize mini.align with user settings
- Add <Leader>ma and <Leader>mA mappings for text alignment
</details>

<details>
<summary>feat(nvim): add mini.align plugin (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/15e2f228939aec94cc30588ff0bed37c4f5e8c68">15e2f22</a>)</summary>

- Add nvim-mini/mini.align to the editor plugin configuration
- Configure plugin to lazy-load on buffer read and new file events
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1686

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
