### PR TITLE
feat(nvim): Update treesitter config

### DIFF
--- a/home/dot_config/nvim/lua/plugins/treesitter.lua
+++ b/home/dot_config/nvim/lua/plugins/treesitter.lua
@@ -22,6 +22,7 @@ return {
     event  = { "BufReadPost", "BufNewFile" },
     config = function() require("user.treesitter.context") end,
   },
+  { "RRethy/nvim-treesitter-endwise", ft = ft.endwise },
   {
     "hiphish/rainbow-delimiters.nvim",
     event  = { "BufReadPost", "BufNewFile" },

--- a/home/dot_config/nvim/lua/user/filetypes.lua
+++ b/home/dot_config/nvim/lua/user/filetypes.lua
@@ -61,6 +61,8 @@ Filetypes.treesitter = {
   "ini", "comment", "editorconfig",
 }
 
+Filetypes.endwise = { "bash", "zsh", "fish", "lua", "luau", "elixir", "ruby", "vim" }
+
 Filetypes.actions = { "yaml.github" }
 
 Filetypes.colorizer = {

--- a/home/dot_config/nvim/lua/user/treesitter/textobjects.lua
+++ b/home/dot_config/nvim/lua/user/treesitter/textobjects.lua
@@ -45,6 +45,14 @@ wk.add({
   { "in", function() select("@number.inner",      "textobjects") end, icon = " ", desc = "Inside number" },
   { "as", function() select("@local.scope",       "textobjects") end, icon = " ", desc = "Local scope" },
 }, { noremap = true })
+
+-- Incremental Selection (treesitter + LSP fallback)
+local ts = require("vim.treesitter._select")
+wk.add({
+  { "an", ts.select_parent(vim.v.count1), mode = nxo, icon = " ", desc = " Outer Node" },
+  { "in", ts.select_child(vim.v.count1),  mode = nxo, icon = " ", desc = " Inner Node" },
+})
+
 -- Swap
 local swap   = require("nvim-treesitter-textobjects.swap")
 local sp, sn = swap.swap_previous, swap.swap_next
@@ -79,8 +87,8 @@ wk.add({
   mode = nxo,
   { ";", repmove.repeat_last_move_previous,              icon = "󰑙 ", desc = "Repeat last move forward" },
   { ",", repmove.repeat_last_move_next,                  icon = "󰑙 ", desc = "Repeat last move backward" },
-  -- { "f", repmove.builtin_f_expr,            expr = true, icon = " ", desc = "Repeat moving with f" },
-  -- { "F", repmove.builtin_F_expr,            expr = true, icon = " ", desc = "Repeat moving with F" },
-  -- { "t", repmove.builtin_t_expr,            expr = true, icon = " ", desc = "Repeat moving with t" },
-  -- { "T", repmove.builtin_T_expr,            expr = true, icon = " ", desc = "Repeat moving with T" },
+  { "f", repmove.builtin_f_expr,            expr = true, icon = " ", desc = "Repeat moving with f" },
+  { "F", repmove.builtin_F_expr,            expr = true, icon = " ", desc = "Repeat moving with F" },
+  { "t", repmove.builtin_t_expr,            expr = true, icon = " ", desc = "Repeat moving with t" },
+  { "T", repmove.builtin_T_expr,            expr = true, icon = " ", desc = "Repeat moving with T" },
 }, { noremap = true })


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add treesitter incremental selection keymaps
- Add nvim-treesitter-endwise plugin

#### 🎉 New Features

<details>
<summary>feat(nvim): add treesitter incremental selection keymaps (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/ed0f859bf1da7efe851327106039894ad72f0115">ed0f859</a>)</summary>

- Implement incremental selection using Neovim's builtin treesitter selection
- Add 'an' and 'in' mappings for outer and inner node selection
- Enable repeatable 'f', 'F', 't', and 'T' movements within textobjects
- Update which-key configurations for enhanced navigation visibility
</details>

<details>
<summary>feat(nvim): add nvim-treesitter-endwise plugin (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/ed40d53886ab4bd2fe898c4abba9a80a2f1707ee">ed40d53</a>)</summary>

- Add nvim-treesitter-endwise to the treesitter plugin configuration
- Enable automatic insertion of 'end' keywords in supported languages
- Configure the plugin to activate for relevant filetypes
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1688

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
