### PR TITLE
feat: Update LSP config

### DIFF
--- a/home/.chezmoidata/lsp.toml
+++ b/home/.chezmoidata/lsp.toml
@@ -62,9 +62,9 @@ exts = [ ".js", ".jsx", "ts", ".tsx", ".vue", ".svelte", ".astro" ]
 cmd  = [ "typescript-language-server", "--stdio" ]
 exts = [ ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts" ]
 
-[lsp.servers.pyright]
-cmd  = [ "pyright-langserver", "--stdio" ]
-exts = [ ".py", ".pyi" ]
+[lsp.servers.ty]
+cmd  = [ "ty", "server" ]
+exts = [ "py" ]
 
 [lsp.servers.texlab]
 cmd  = [ "texlab" ]

--- a/home/dot_config/nvim/lua/plugins/lsp.lua
+++ b/home/dot_config/nvim/lua/plugins/lsp.lua
@@ -3,6 +3,7 @@
 return {
   {
     "neovim/nvim-lspconfig",
+    event  = { "BufReadPre", "BufNewFile" },
     config = function() require("lsp.config") end,
   },
   { "folke/lazydev.nvim", ft = "lua", opts = {} },


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Optimize lspconfig loading in nvim
- Replace pyright with ty for python in lsp

#### 🎉 New Features

<details>
<summary>feat(lsp): replace pyright with ty for python (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/e9f668dd">e9f668dd</a>)</summary>

- Switch the default Python LSP server from pyright to ty
- Update server command to use 'ty server'
- Restrict supported extensions to 'py' for the new server
</details>

#### Other Changes

<details>
<summary>perf(nvim): optimize lspconfig loading (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/5b18bb55">5b18bb55</a>)</summary>

- Add lazy loading events to nvim-lspconfig plugin
- Defer configuration until BufReadPre or BufNewFile events
- Reduce initial Neovim startup time by lazy loading LSP
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1692

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
