### PR TITLE
feat(nvim): Update builtin plugins

### DIFF
--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -51,6 +51,8 @@ lazy.setup("plugins", {
       reset = true, -- reset the runtime path to $VIMRUNTIME and the config directory
       -- paths = {}, -- add any custom paths here that you want to include in the rtp
       disabled_plugins = {
+        "bugreport", "compiler",
+        "getscript", "getscriptPlugin", "optwin",
         "zip", "zipPlugin", "gzip",
         "tar", "tarPlugin",
         "getscript", "getscriptPlugin",
@@ -58,8 +60,8 @@ lazy.setup("plugins", {
         "matchit", "matchparen",
         "netrw", "netrwPlugin",
         "netrwSettings", "netrwFileHandlers",
-        "rrhelper", -- "spellfile_plugin",
-        "tohtml",
+        "rplugin", "rrhelper", -- "spellfile_plugin",
+        "synmenu", "tohtml",
         "logipat",
         "tutor",
       }

--- a/home/dot_config/nvim/lua/core/base.lua
+++ b/home/dot_config/nvim/lua/core/base.lua
@@ -34,7 +34,7 @@ vim.opt.visualbell = true
 -- Clipboard
 vim.opt.clipboard = "unnamedplus"
 
--- Sroll
+-- Scroll
 vim.opt.scrolloff  = 2
 
 -- Tab
@@ -55,6 +55,7 @@ vim.opt.backspace   = "eol,indent,start"
 -- disable menu loading
 vim.g.did_install_default_menus = 1
 vim.g.did_install_syntax_menu   = 1
+vim.g.did_indent_on = 1
 
 vim.g.loaded_spellfile_plugin = 1
 
@@ -69,8 +70,13 @@ vim.g.loaded_tarPlugin     = 1
 vim.g.loaded_vimball       = 1
 vim.g.loaded_vimballPlugin = 1
 
-vim.g.loaded_matchit    = 1
-vim.g.loaded_matchparen = 1
+vim.g.loaded_matchit           = 1
+vim.g.loaded_matchparen        = 1
+vim.g.loaded_netrwPlugin       = 1
+vim.g.loaded_remote_plugins    = 1
+vim.g.loaded_shada_plugin      = 1
+vim.g.loaded_spellfile_plugin  = 1
+vim.g.loaded_tutor_mode_plugin = 1
 
 -- Disable sql omni completion.
 vim.g.loaded_sql_completion = 1
@@ -82,6 +88,4 @@ vim.g.netrw_liststyle = 3
 
 vim.g.loaded_2html_plugin = 1
 
--- https://zenn.dev/kawarimidoll/articles/8172a4c29a6653
-vim.g.did_install_default_menus = 1
 vim.g.skip_loading_mswin        = 1


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Disable additional Neovim builtin plugins for a leaner core configuration
- Refine core configuration with typo fixes and removal of redundant code

#### Other Changes

<details>
<summary>chore(nvim): disable more builtin plugins in core config (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7f40accf6621b87cdf79bff154ed6e37d4684d5a">7f40acc</a>)</summary>

- Fix typo in "Scroll" comment
- Disable indent_on, netrwPlugin, and remote_plugins
- Disable shada_plugin, spellfile_plugin, and tutor_mode_plugin
- Remove duplicate assignment of default menu installation flag
</details>

<details>
<summary>chore(nvim): disable additional builtin plugins (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/f303aabc72395b77902b0e59cfe3b36f43deb80f">f303aab</a>)</summary>

- Add bugreport, compiler, and optwin to the disabled plugins list
- Include rplugin and synmenu in the list of disabled builtins
- Reorganize the disabled_plugins configuration in lazy.setup
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1693

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
