### PR TITLE
feat: Update nvim completion

### DIFF
--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -122,9 +122,10 @@ blink.setup({
       },
     },
     trigger = {
-      show_in_snippet = false,
-      show_on_insert_on_trigger_character = false,
+      show_on_trigger_character = true,
+      show_on_insert_on_trigger_character = true,
       show_on_accept_on_trigger_character = false,
+      show_on_blocked_trigger_characters = { " ", "\n", "\t" },
     },
     menu = {
       winblend   = 20,

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -9,31 +9,17 @@ local ls = require("luasnip")
 blink.setup({
   ---@see https://cmp.saghen.dev/configuration/keymap.html
   keymap = {
-    preset = "none", ---@type "default"|"super-tab"|"enter"|"none"
-    ["<Tab>"] = {
-      function(cmp)
-        if cmp.is_visible() then
-          return cmp.select_and_accept()
-        elseif cmp.snippet_active({ direction = 1 }) then
-          return cmp.snippet_forward()
-        elseif require("sidekick.nes").have() then
-          require("sidekick").nes_jump_or_apply()
-        end
-      end,
-      "fallback",
-    },
-    ["<S-Tab>"] = {
-      function(cmp)
-        if cmp.snippet_active({ direction = -1 }) then
-          return cmp.snippet_backward()
-        end
-      end,
-      "fallback",
-    },
-    ["<Up>"]    = { "show_and_insert", "select_prev", "fallback" },
-    ["<Down>"]  = { "show_and_insert", "select_next", "fallback" },
-    ["<Left>"]  = { "hide", "fallback" },
-    ["<Right>"] = { "select_and_accept", "fallback" },
+    preset = "default", ---@type "default"|"super-tab"|"enter"|"none"
+    ["<C-c>"] = { "cancel", "fallback" },
+    ["<C-e>"] = { "hide", "fallback" },
+    ["<C-y>"] = { "select_and_accept" },
+    ["<C-b>"] = { "scroll_documentation_up", "fallback" },
+    ["<C-f>"] = { "scroll_documentation_down", "fallback" },
+    ["<C-s>"] = { "show_signature", "hide_signature", "fallback" },
+    ["<S-k>"] = { "show", "show_documentation", "hide_documentation", "fallback" },
+
+    ["<Tab>"]   = { "snippet_forward", "select_next", "fallback" },
+    ["<S-Tab>"] = { "snippet_backward", "select_prev", "fallback" },
     ["<C-p>"]   = {
       function(_)
         if ls.choice_active() then
@@ -54,13 +40,11 @@ blink.setup({
       "select_next",
       "fallback_to_mappings",
     },
-    ["<C-d>"]   = { "show", "show_documentation", "hide_documentation", "fallback" },
-    ["<C-s>"]   = { "show_signature", "hide_signature", "fallback" },
-    ["<C-b>"]   = { "scroll_documentation_up", "fallback" },
-    ["<C-f>"]   = { "scroll_documentation_down", "fallback" },
-    ["<C-.>"]   = { "hide", "fallback" },
-    ["<C-c>"]   = { "cancel", "fallback" },
-    ["<CR>"]    = { "accept", "fallback" },
+    ["<Up>"]    = { "select_prev", "fallback" },
+    ["<Down>"]  = { "select_next", "fallback" },
+    ["<Left>"]  = { "hide", "fallback" },
+    ["<Right>"] = { "select_and_accept", "fallback" },
+
   },
 
   appearance = {

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -60,11 +60,11 @@ blink.setup({
 
     per_filetype = {
       lua      = { "lazydev", "lsp", "snippets", "path", "buffer" },
-      markdown = { "lsp", "snippets", "path", "buffer", "markdown" },
+      markdown = { "markdown", "lsp", "snippets", "path", "buffer" },
     },
     providers = {
       lazydev  = { name = "LazyDev",        module = "lazydev.integrations.blink",  score_offset = 100 },
-      markdown = { name = 'RenderMarkdown', module = "render-markdown.integ.blink", score_offset = 20 },
+      markdown = { name = 'RenderMarkdown', module = "render-markdown.integ.blink", fallbacks = { "lsp" } },
     },
   },
 

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -111,12 +111,7 @@ blink.setup({
     accept     = { auto_brackets = { enabled = true } },
     keyword    = { range = "full" },
 
-    documentation = {
-      auto_show = true,
-      auto_show_delay_ms = 100,
-      treesitter_highlighting = true,
-      window = { border = "rounded" },
-    },
+    documentation = { auto_show = true, auto_show_delay_ms = 100 },
     list = {
       max_items = 15,
       selection = {

--- a/home/dot_config/nvim/lua/lsp/cmp/blink.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/blink.lua
@@ -128,9 +128,7 @@ blink.setup({
       show_on_blocked_trigger_characters = { " ", "\n", "\t" },
     },
     menu = {
-      winblend   = 20,
-      min_width  = 25,
-      max_height = 40,
+      winblend = 20,
       auto_show = function(ctx)
         return ctx.mode ~= "cmdline" or not vim.tbl_contains({ "/", "?" }, vim.fn.getcmdtype())
       end,


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Update completion trigger behavior in blink.cmp
- Simplify keymap, documentation, and menu configuration for blink.cmp
- Refactor markdown completion providers with fallback mechanism

#### 🎉 New Features

<details>
<summary>feat(nvim): update blink completion trigger behavior (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/a43b5843752d745b1c3c996e4c2ee96446d77586">a43b584</a>)</summary>

- Enable completion trigger on both normal and insert mode trigger characters
- Add blocked trigger characters for space, newline, and tab
- Remove redundant show-in-snippet configuration
</details>

#### Other Changes

<details>
<summary>refactor(nvim): update markdown completion providers (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/70d3b20b4733b56d74f960652db4af8440d6ce21">70d3b20</a>)</summary>

- Reorder markdown completion sources to prioritize RenderMarkdown
- Replace score_offset with fallbacks in RenderMarkdown provider
- Standardize provider configuration for better completion behavior
</details>

<details>
<summary>refactor(nvim/blink): simplify completion menu configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/2528ece61fd9ef85f49ef630c99e893c20e98c5b">2528ece</a>)</summary>

- Remove redundant dimension constraints from the menu setup
- Streamline blink.cmp configuration by relying on default behaviors
</details>

<details>
<summary>refactor(nvim): simplify blink documentation configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/fa4adffc34a9fcedbecf02352bc2064e9e905e4d">fa4adff</a>)</summary>

- Remove redundant treesitter highlighting and window border settings
- Consolidate documentation table to a single line
- Maintain existing auto-show behavior and delay
</details>

<details>
<summary>refactor(nvim): simplify blink keymap configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/67f61e95c8a6efb43645e3b136c55b69595eb632">67f61e9</a>)</summary>

- Switch keymap preset to default and remove complex custom handlers
- Add new keybindings for cancel, hide, and documentation scrolling
- Standardize snippet navigation using built-in blink actions
- Reorganize and clean up redundant mapping definitions
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1700

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
