### PR TITLE
feat(mise): Add fnox secrets manager

### DIFF
--- a/home/dot_config/fnox/config.toml.tmpl
+++ b/home/dot_config/fnox/config.toml.tmpl
@@ -1,0 +1,20 @@
+default_provider = "keychain"
+
+[providers.keychain]
+type    = "keychain"
+service = "fnox"
+
+# [providers.age]
+# type       = "age"
+# key_file   = {{ joinPath (env "XDG_CONFIG_HOME") "fnox" "key.txt" | quote }}
+# recipients = [""]
+
+# [providers.1password]
+# type = "1password"
+
+[secrets]
+# EXAMPLE_SECRET= { provider = "keychain" }
+
+{{- /*
+# -*-mode:toml-*- vim:ft=toml.gotexttmpl
+*/ -}}

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -181,6 +181,7 @@ ruby    = "3"
 ## Security
 "aqua:FiloSottile/age"   = "latest" # Simple encrypt / decrypt tool
 "aqua:gitleaks/gitleaks" = "latest" # tool for detecting secrets like passwords, API keys, and tokens in repos
+"github:jdx/fnox"        = "latest" # encrypted/remote secret manager
 
 ## Container
 "aqua:lima-vm/lima"     = "latest" # Linux virtual machines, with a focus on running containers


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add fnox secret manager to mise configuration
- Initialize fnox configuration template with keychain support

#### 🎉 New Features

<details>
<summary>feat(fnox): add initial configuration template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/a4ca5e9fe8ae1d69169279e04df668d43b093d18">a4ca5e9</a>)</summary>

- Create config.toml.tmpl for fnox secret manager
- Set keychain as the default secret provider
- Include templates for age and 1Password providers
</details>

<details>
<summary>feat(mise): add fnox secret manager (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/98474d7e8a12371ca41f046f3d0dbbc84497859e">98474d7</a>)</summary>

- Add jdx/fnox to mise configuration for encrypted secret management
- Configure automatic installation of latest fnox version
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1735

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
