### PR TITLE
feat: Update nvim keymaps

### DIFF
--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -287,7 +287,7 @@ if not is_vscode then
     },
     {
       "<Leader>ft",
-      "<CMD>lua Snacks.picker.todo_comments({ keywords = {'TODO', 'FIX', 'FIXME'} })<CR>",
+      "<CMD>lua Snacks.picker.grep({ pattern = 'TODO|HACK|PERF|NOTE|FIX|FIXME|WARNING' })<CR>",
       icon = " ",
       desc = " TODO/Fix/Fixme",
     },

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -78,10 +78,21 @@ wk.add({
   { "R",     "<CMD>lua require'flash'.treesitter_search()<CR>", mode = ox,  icon = " ", desc = " Treesitter Search" },
   { "<C-s>", "<CMD>lua require'flash'.toggle()<CR>",            mode = c,   icon = " ", desc = " Toggle" },
 
-  { "<Leader>jl", "<CMD>FlashJumpLine<CR>",  mode = nxo, icon = " ", desc = " Jump to the line" },
-  { "<Leader>jw", "<CMD>FlashJumpWord<CR>",  mode = nxo ,icon = " ", desc = " Jump to the word" },
-  { "<Leader>*",  "<CMD>FlashJumpCword<CR>", mode = nxo, icon = "󰀬 ", desc = " Jump to <cword>" },
-  { "<Leader>.",  "<CMD>FlashJumpContinue<CR>",          icon = " ", desc = " Continue last search" },
+  {
+    "<Leader>jl",
+    "<CMD>lua require'flash'.jump({pattern='^\\s*\\S\\?',jump={pos='end'},search={mode='search'}})<CR>",
+    mode = nxo,
+    icon = " ",
+    desc = " Jump to the line"
+  },
+  {
+    "<Leader>*",
+    "<CMD>lua require'flash'.jump({ pattern = vim.fn.expand('<cword>') })<CR>",
+    mode = nxo,
+    icon = "󰀬 ",
+    desc = " Jump to <cword>"
+  },
+  {"<Leader>.", "<CMD>lua require'flash'.jump({ continue = true })<CR>", icon = " ", desc = " Continue last search"},
 }, opts)
 
 ---------------------------------------------------------------------------

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -232,8 +232,8 @@ if not is_vscode then
     { "<Leader>f:", "<CMD>lua Snacks.picker.command_history()<CR>", icon = " ", desc = " Command History" },
 
     -- Grep
-    { "<C-g>",         "<CMD>lua Snacks.picker.grep()<CR>",                 icon = " ", desc = " Live Grep" },
-    { "<Leader><C-g>", "<CMD>lua Snacks.picker.grep_word()<CR>", mode = nx, icon = " ", desc = " grep with cword" },
+    { "<C-g>",      "<CMD>lua Snacks.picker.grep()<CR>",                 icon = " ", desc = " Live Grep" },
+    { "<Leader>fw", "<CMD>lua Snacks.picker.grep_word()<CR>", mode = nx, icon = " ", desc = " grep with cword" },
 
     -- Vim
     { "<Leader>f?",  "<CMD>lua Snacks.picker.help()<CR>",         icon = " ", desc = " Help" },

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -287,7 +287,7 @@ if not is_vscode then
     },
     {
       "<Leader>ft",
-      "<CMD>lua Snacks.picker.grep({ pattern = 'TODO|HACK|PERF|NOTE|FIX|FIXME|WARNING' })<CR>",
+      "<CMD>lua Snacks.picker.grep({ focus = 'list' , search = 'TODO|HACK|PERF|NOTE|FIX|FIXME|WARNING' })<CR>",
       icon = " ",
       desc = " TODO/Fix/Fixme",
     },

--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -290,10 +290,10 @@ wk.add({
   { "<Leader>L",  "<CMD>Lazy<CR>",  icon = " ", desc = " lazy.nvim" },
 
   { "<Leader>l", group = "LSP", icon = "🚦 " },
-  { "<Leader>le", "<CMD>lsp enable",  icon = " ", desc = " Enable Language Server" },
-  { "<Leader>ld", "<CMD>lsp disable", icon = " ", desc = " Disable Language Server " },
-  { "<Leader>lr", "<CMD>lsp restart", icon = " ", desc = " Restart Language Server " },
-  { "<Leader>ls", "<CMD>lsp stop",    icon = " ", desc = " Stop Language Server " },
+  { "<Leader>le", "<CMD>lsp enable<CR>",  icon = " ", desc = " Enable Language Server" },
+  { "<Leader>ld", "<CMD>lsp disable<CR>", icon = " ", desc = " Disable Language Server " },
+  { "<Leader>lr", "<CMD>lsp restart<CR>", icon = " ", desc = " Restart Language Server " },
+  { "<Leader>ls", "<CMD>lsp stop<CR>",    icon = " ", desc = " Stop Language Server " },
 
   { "<Leader>lc", "<CMD>lua Snacks.picker.lsp_config()<CR>",           icon = " ", desc = " Display LSP Info" },
   { "<Leader>li", "<CMD>lua Snacks.picker.lsp_implementations()<CR>",  icon = " ", desc = " Implementations" },

--- a/home/dot_config/nvim/lua/lsp/cmp/luasnip.lua
+++ b/home/dot_config/nvim/lua/lsp/cmp/luasnip.lua
@@ -264,8 +264,7 @@ local function dynamic_node_external_update(func_indx)
 end
 
 require("which-key").add({
-  { "<C-t>", function() dynamic_node_external_update(1) end, mode = "i", icon = " ", desc = "" },
-  { "<C-t>", function() dynamic_node_external_update(1) end, mode = "s", icon = " ", desc = "" },
-  { "<C-g>", function() dynamic_node_external_update(2) end, mode = "i", icon = " ", desc = "" },
-  { "<C-g>", function() dynamic_node_external_update(2) end, mode = "s", icon = " ", desc = "" },
+  mode = { "i", "s" },
+  { "<C-t>", function() dynamic_node_external_update(1) end, icon = "󰒮 ", desc = " remove one row in a dynamic node" },
+  { "<C-g>", function() dynamic_node_external_update(2) end, icon = "󰒭 ", desc = " add one row in a dynamic node" },
 }, { noremap = true })

--- a/home/dot_config/nvim/lua/user/flash.lua
+++ b/home/dot_config/nvim/lua/user/flash.lua
@@ -28,37 +28,3 @@ flash.setup({
   remote_op = {},
   exclude = require("core.ignore").flash,
 })
-vim.api.nvim_create_user_command("FlashJumpLine", function(_)
-  flash.jump({
-    pattern   = "^\\s*\\S\\?",
-    jump      = { pos = "end" },
-    search    = { mode = "search", max_length = 0 },
-    label     = { after = { 0, 0 } },
-    highlight = { matches = false },
-  })
-end, { desc = "Jump to the line (non-whitespace at start plus any character)", nargs = "*", bang = true })
-
-vim.api.nvim_create_user_command("FlashJumpCword", function(_)
-  flash.jump({ pattern = vim.fn.expand("<cword>") })
-end, { desc = "Jump to <cword>", nargs = "*", bang = true })
-
-vim.api.nvim_create_user_command("FlashJumpWord", function(_)
-  flash.jump({
-    pattern = ".", -- initialize pattern with any char
-    search  = {
-      mode = function(pattern)
-        if pattern:sub(1, 1) == "." then
-          pattern = pattern:sub(2)
-        end
-        -- return word pattern and proper skip pattern
-        return ([[\<%s\w*\>]]):format(pattern), ([[\<%s]]):format(pattern)
-      end
-    },
-    -- select the range
-    jump = { pos = "range" },
-  })
-end, { desc = "Jump to the word", nargs = "*", bang = true })
-
-vim.api.nvim_create_user_command("FlashJumpContinue", function(_)
-  flash.jump({ continue = true })
-end, { desc = "Continue last search", nargs = "*", bang = true })

--- a/home/dot_config/nvim/lua/user/surround.lua
+++ b/home/dot_config/nvim/lua/user/surround.lua
@@ -18,5 +18,5 @@ surround.setup({
   },
 })
 
-pcall(vim.keymap.del, { "n" }, "gs")
-pcall(vim.keymap.del, { "n", "x" }, "gS")
+-- pcall(vim.keymap.del, { "n" }, "gs")
+-- pcall(vim.keymap.del, { "n", "x" }, "gS")

--- a/home/dot_config/nvim/lua/user/treesitter/textobjects.lua
+++ b/home/dot_config/nvim/lua/user/treesitter/textobjects.lua
@@ -46,13 +46,6 @@ wk.add({
   { "as", function() select("@local.scope",       "textobjects") end, icon = " ", desc = "Local scope" },
 }, { noremap = true })
 
--- Incremental Selection (treesitter + LSP fallback)
-local ts = require("vim.treesitter._select")
-wk.add({
-  { "an", ts.select_parent(vim.v.count1), mode = nxo, icon = " ", desc = " Outer Node" },
-  { "in", ts.select_child(vim.v.count1),  mode = nxo, icon = " ", desc = " Inner Node" },
-})
-
 -- Swap
 local swap   = require("nvim-treesitter-textobjects.swap")
 local sp, sn = swap.swap_previous, swap.swap_next

--- a/home/dot_config/nvim/lua/user/which-key.lua
+++ b/home/dot_config/nvim/lua/user/which-key.lua
@@ -14,9 +14,25 @@ wk.setup({
   spec     = {},
   notify   = true,
   triggers = { "<auto>", "nxso" },
-  defer    = function(ctx) return ctx.mode == "V" or ctx.mode == "<C-V>" end,
+  -- Start hidden and wait for a key to be pressed before showing the popup
+  -- defer    = function(ctx)
+  --   return vim.list_contains({ "d", "y" }, ctx.operator) or vim.list_contains({ "V", "<C-V>" }, ctx.mode)
+  -- end,
 
-  plugins = {},
+  plugins = {
+    marks     = true, -- shows a list of your marks on ' and `
+    registers = true, -- shows your registers on " in NORMAL or <C-r> in INSERT mode
+
+    presets = {
+      operators    = true, -- adds help for operators like d, y, ...
+      motions      = true, -- adds help for motions
+      text_objects = true, -- help for text objects triggered after entering an operator
+      windows      = true, -- default bindings on <c-w>
+      nav          = true, -- misc bindings to work with windows
+      z            = true, -- bindings for folds, spelling and others prefixed with z
+      g            = true, -- bindings for prefixed with g
+    },
+  },
   win = {
     no_overlap = true,
     padding = { 1, 2 }, -- extra window padding [top/bottom, right/left]
@@ -30,7 +46,7 @@ wk.setup({
   layout = {
     spacing = 3,
     align   = "center", ---@type "left"|"right"|"center"
-		width  = { min = 5, max = 50 }, -- min and max width of the columns
+    width  = { min = 5, max = 50 }, -- min and max width of the columns
   },
   keys    = {},
   sort    = {},


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Enhanced which-key configuration with more presets and integrations
- Expanded TODO search capabilities with more keywords and switched to grep picker
- Updated various Neovim keybindings for consistency (mnemonic `<Leader>fw` for grep word)
- Refactored treesitter, luasnip, and snacks picker configurations for better clarity and API alignment

#### 🎉 New Features

<details>
<summary>feat(nvim): enhance which-key plugin configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/4b0d6e598ff57b62b087d9cef44159cc64c17914">4b0d6e5</a>)</summary>

- Enable marks and registers plugin integrations
- Activate presets for operators, motions, text objects, and window navigation
- Comment out defer logic to adjust popup visibility behavior
</details>

<details>
<summary>feat(nvim): expand todo search keywords and use grep picker (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/9b568a1a3bea27d80f064b7372ad527e09dd5ea2">9b568a1</a>)</summary>

- Replace Snacks.picker.todo_comments with Snacks.picker.grep for more flexibility
- Add HACK, PERF, NOTE, and WARNING to the list of tracked keywords
- Update the todo search keymap to capture a wider range of development notes
</details>

#### Other Changes

<details>
<summary>refactor(nvim): comment out surround keymap deletions (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/d549c31737ca9a839c890a9c92da3aedffed3653">d549c31</a>)</summary>

- Comment out the pcall for deleting gs and gS keymaps
- Maintain existing keybindings while testing configuration changes
- Prevent accidental deletion of global search/surround mappings
</details>

<details>
<summary>refactor(nvim): remove internal treesitter select keymaps (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/daf1ad33d76609873199159553992683cbc2b9b6">daf1ad3</a>)</summary>

- Remove usage of internal vim.treesitter._select module
- Delete keybindings for parent and child node selection
- Simplify treesitter textobjects configuration
</details>

<details>
<summary>refactor(nvim): update luasnip dynamic node keymaps (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/3aa5f636d2d30d03135e9365a5a460a98690ccc7">3aa5f63</a>)</summary>

- Consolidate mode definitions for <C-t> and <C-g> keymaps
- Add icons and descriptions for dynamic node row management
- Improve clarity of luasnip keymap configuration
</details>

<details>
<summary>refactor(nvim): update snacks picker todo search configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/515aecc80c9cb48547e6ecb93f41126f355500b4">515aecc</a>)</summary>

- Change `pattern` to `search` parameter in `Snacks.picker.grep`
- Add `focus = 'list'` to automatically focus the results list
- Align configuration with the latest Snacks.nvim API usage
</details>

<details>
<summary>refactor(nvim): update grep word keybinding to &lt;Leader&gt;fw (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/96877d312aa195a8b57585176b43603732815c5d">96877d3</a>)</summary>

- Change grep word mapping from <Leader><C-g> to <Leader>fw
- Improve mnemonic consistency for search-related operations
- Adjust indentation alignment in picker keymap definitions
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1737

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
