### PR TITLE
feat: Update snacks picker

### DIFF
--- a/home/dot_config/nvim/lua/user/snacks/picker/init.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/init.lua
@@ -61,6 +61,7 @@ return {
         ["<c-f>"] = { "list_scroll_down",    mode = { "i", "n" } },
         ["<c-t>"] = { "edit_tab",            mode = { "i", "n" } },
         ["<c-i>"] = { "toggle_focus",        mode = { "i", "n" } },
+        ["<c-x>"] = { "trouble_open",        mode = { "i", "n" } },
 
         ["s"]     = { "flash" },
         ["<a-s>"] = { "flash",         mode = { "n", "i" } },

--- a/home/dot_config/nvim/lua/user/snacks/picker/init.lua
+++ b/home/dot_config/nvim/lua/user/snacks/picker/init.lua
@@ -81,6 +81,25 @@ return {
   },
 
   actions = {
+    trouble_open = function(...)
+      require("trouble.sources.snacks").actions.trouble_open(...)
+    end,
+    trouble_open_selected = function(...)
+      require("trouble.sources.snacks").actions.trouble_open_selected(...)
+    end,
+    trouble_open_all = function(...)
+      require("trouble.sources.snacks").actions.trouble_open_all(...)
+    end,
+    trouble_open_add = function(...)
+      require("trouble.sources.snacks").actions.trouble_open_add(...)
+    end,
+    trouble_open_add_selected = function(...)
+      require("trouble.sources.snacks").actions.trouble_open_add_selected(...)
+    end,
+    trouble_open_add_all = function(...)
+      require("trouble.sources.snacks").actions.trouble_open_add_all(...)
+    end,
+
     flash = function(picker)
       require("flash").jump({
         pattern = "^",


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add trouble.nvim integration to Neovim's snacks picker
- Add `<c-x>` keybinding to open picker results in `trouble.nvim`

#### 🎉 New Features

<details>
<summary>feat(nvim): add trouble_open keybinding to snacks picker (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/67bbcbf82a718419e165c7c5cdd8efa3a0978bb1">67bbcbf</a>)</summary>

- Add <c-x> mapping to open picker results in Trouble
- Support both insert and normal modes for the new mapping
</details>

<details>
<summary>feat(nvim): add trouble.nvim integration to snacks picker (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/59a3c2ecc55419aba42883d6148ba4a365020c8a">59a3c2e</a>)</summary>

- Implement support for opening picker results in Trouble
- Add actions for opening all, selected, or current items
- Add actions for appending items to an existing Trouble list
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1745

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
