### PR TITLE
feat: Update global editorconfig

### DIFF
--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -15,12 +15,10 @@ indent_style = tab
 
 # Markdown
 [*.{md,mdx}]
-indent_style = space
 indent_size  = 2
 
 # Shell Script
 [*.{sh,zsh,fish,fish.symlink}]
-indent_style = space
 indent_size  = 2
 
 # Makefile
@@ -30,13 +28,11 @@ indent_size  = 4
 
 # C/C++, Rust
 [*.{c,cc,cpp,h,hpp,rs}]
-indent_style = space
 indent_size  = 4
 tab_width    = 4
 
 # Shader Languages
 [*.{glsl,frag,vert,geom,comp,tese,tesc,metal}]
-indent_style = space
 indent_size  = 4
 tab_width    = 4
 
@@ -52,7 +48,6 @@ indent_size  = 4
 
 # JavaScript / Typescript
 [*.{js,jsx,ts,tsx,cjs,cts,mjs,mts,vue,svelte,astro}]
-indent_style = space
 indent_size  = 2
 
 # Lua
@@ -61,7 +56,6 @@ max_line_length = 120
 
 # Python
 [*.{py,pyw}]
-indent_style = space
 indent_size  = 4
 max_line_length = 120
 
@@ -80,7 +74,6 @@ max_line_length = 120
 
 # KDL
 [*.{kdl,kdl.tmpl}]
-indent_style = space
 indent_size  = 4
 
 # HTML & CSS

--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -86,8 +86,7 @@ indent_size  = 4
 # HTML & CSS
 [*.{html,css,scss}]
 indent_style    = tab
-indent_size     = 2
-max_line_length = 80
+max_line_length = 120
 
 # TeX
 [*.{tex,bib}]
@@ -97,8 +96,7 @@ indent_size  = 2
 # GraphQL
 [*.{gql,graphql}]
 indent_style    = tab
-indent_size     = 2
-max_line_length = 80
+max_line_length = 120
 
 {{- /*
 # -*-mode:editorconfig-*- vim:ft=editorconfig.gotexttmpl

--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -23,22 +23,10 @@ indent_size  = 2
 indent_style = space
 indent_size  = 2
 
-# Nushell
-[*.{nu}]
-indent_style = space
-indent_size  = 4
-insert_final_newline     = false
-trim_trailing_whitespace = true
-
 # Makefile
 [{Makefile}]
 indent_style = tab
 indent_size  = 4
-
-# Taskfile
-[Taskfile.{yml,yaml}]
-indent_size  = 2
-indent_style = space
 
 # C/C++, Rust
 [*.{c,cc,cpp,h,hpp,rs}]

--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -53,7 +53,7 @@ indent_size  = 4
 tab_width    = 4
 
 # Go
-[*.{go}]
+[{*.{go},go.mod,go.sum,go.work}]
 indent_style = tab
 indent_size  = 4
 

--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -9,6 +9,10 @@ indent_size  = 2
 insert_final_newline     = true
 trim_trailing_whitespace = true
 
+# Git
+[{.gitconfig*,.git/config}]
+indent_style = tab
+
 # Markdown
 [*.{md,mdx}]
 indent_style = space

--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -57,8 +57,6 @@ indent_size  = 2
 
 # Lua
 [*.{lua,lua.tmpl}]
-indent_style = space
-indent_size  = 2
 max_line_length = 120
 
 # Python
@@ -69,8 +67,6 @@ max_line_length = 120
 
 # Ruby
 [*.{rb,rbi,rbw,ru,gemspec,jbuilder,erb,slim,haml,Gemfile{,.lock},Rakefile,Guradfile,Brewfile,Caskfile,Masfile}]
-indent_style = space
-indent_size  = 2
 max_line_length = 120
 
 # TOML

--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -90,16 +90,9 @@ max_line_length = 120
 indent_style = space
 indent_size  = 2
 
-# JSON
-[*.{json,jsonc,json5}]
-indent_style    = tab
-indent_size     = 2
+# JSON / YAML
+[*.{json,jsonc,json5,y{a}ml}]
 max_line_length = 120
-
-# YAML
-[*.{y{a}ml}]
-indent_style = space
-indent_size  = 2
 
 # KDL
 [*.{kdl,kdl.tmpl}]

--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -1,10 +1,12 @@
-# -*-mode:toml-*- vim:ft=toml.gotexttmpl
 root = true
 
 [*]
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
+charset      = utf-8
+end_of_line  = lf
+indent_style = space
+indent_size  = 2
+
+insert_final_newline     = true
 trim_trailing_whitespace = true
 
 # Markdown
@@ -116,3 +118,7 @@ indent_size  = 2
 indent_style    = tab
 indent_size     = 2
 max_line_length = 80
+
+{{- /*
+# -*-mode:editorconfig-*- vim:ft=editorconfig.gotexttmpl
+*/ -}}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Standardized global indentation to 2 spaces and improved formatting alignment.
- Added specific tab-based indentation for Git configuration and Go module files.
- Consolidated JSON, YAML, Nushell, and Taskfile rules to reduce redundancy.
- Increased maximum line length to 120 for HTML, CSS, SCSS, and GraphQL files.
- Removed redundant language-specific indentation settings to leverage global defaults.

#### Other Changes

<details>
<summary>style(editorconfig): remove redundant space indentation rules (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/4235340b">4235340b</a>)</summary>

- Remove explicit space indentation from Markdown, Shell, and C/C++ sections
- Remove redundant settings for TOML, Python, KDL, and Shader languages
- Rely on global settings to maintain a DRY configuration
</details>

<details>
<summary>style(editorconfig): update line length and indent for web files (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b2685bda">b2685bda</a>)</summary>

- Increase max line length to 120 for HTML, CSS, SCSS, and GraphQL
- Remove redundant indentation size for tab-based formats
</details>

<details>
<summary>style(editorconfig): remove redundant indentation rules (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b3c2dcac">b3c2dcac</a>)</summary>

- Remove explicit indentation settings for JS/TS and Python sections
- Leverage global indentation defaults for improved maintainability
- Simplify configuration by eliminating redundant property declarations
</details>

<details>
<summary>style(editorconfig): remove nushell and taskfile rules (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/da59f217">da59f217</a>)</summary>

- Remove specific indentation rules for Nushell and Taskfile
- Rely on global or consolidated YAML configuration for these files
- Simplify configuration by removing unused language-specific blocks
</details>

<details>
<summary>style(editorconfig): consolidate json and yaml rules (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/ab015c88">ab015c88</a>)</summary>

- Merge JSON and YAML patterns into a single configuration block
- Remove redundant indentation specifications to use global defaults
- Maintain consistent 120 character line length limit
</details>

<details>
<summary>style(editorconfig): include go module files in tab rule (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/032b95b3">032b95b3</a>)</summary>

- Expand Go file pattern to include go.mod, go.sum, and go.work
- Ensure consistent tab-based indentation for all Go-related files
</details>

<details>
<summary>style(editorconfig): set tab indentation for git config (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/93bbad36">93bbad36</a>)</summary>

- Add specific indentation rule for Git configuration files
- Use tabs instead of spaces for .gitconfig and .git/config
</details>

<details>
<summary>style(editorconfig): standardize indentation and formatting (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/18761fee">18761fee</a>)</summary>

- Set default indentation to 2 spaces and use spaces
- Align property values for better readability
- Add template comment for filetype detection
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1747

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
