### PR TITLE
feat(ai): Update GitHub CLI extensions

### DIFF
--- a/home/.chezmoidata/gh.toml
+++ b/home/.chezmoidata/gh.toml
@@ -2,7 +2,6 @@
 
 [extensions]
 gh = [
-  "github/gh-aw",                 # GitHub Agentic Workflows
   "seachicken/gh-poi",            # Safely clean up your local branches
   "dlvhdr/gh-dash",               # Dashboard
   "kawarimidoll/gh-graph",        # Activity graph

--- a/home/.chezmoidata/gh.toml
+++ b/home/.chezmoidata/gh.toml
@@ -8,5 +8,4 @@ gh = [
   "kawarimidoll/gh-graph",        # Activity graph
   "meiji163/gh-notify",           # Notification Extension
   "gennaro-tedesco/gh-s",         # Search repositories interactively
-  "yusukebe/gh-markdown-preview", # Preview markdown looks like GitHub
 ]


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Remove unused GitHub CLI extensions (gh-aw and gh-markdown-preview) to prune the configuration.

#### Other Changes

<details>
<summary>chore(gh): remove gh-aw extension (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/210edaafdc41f61a686782b73d1d7aa51bfcc460">210edaaf</a>)</summary>

- Remove github/gh-aw from GitHub CLI extensions list
- Update gh.toml configuration to prune unused extension
</details>

<details>
<summary>chore(gh): remove gh-markdown-preview extension (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/a7b473a44759a59c2275b515160cf5bfc7348418">a7b473a4</a>)</summary>

- Remove yusukebe/gh-markdown-preview from GitHub CLI extensions list
- Clean up unused extension in gh.toml configuration
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1757

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
