### PR TITLE
feat: Opt out GitHub CLI telemetry

### DIFF
--- a/home/dot_config/fish/conf.d/env.fish.tmpl
+++ b/home/dot_config/fish/conf.d/env.fish.tmpl
@@ -46,7 +46,10 @@ set -gx _ZO_EXCLUDE_DIRS "**/.git/**:**/node_modules/**:**/tmp/**:**/dist/**:**/
 {{- end }}
 set -gx _ZO_FZF_OPTS "--preview 'eza --tree --long --header --color=always --group-directories-first --hyperlink {} || echo \"No Preview\"' --exit-0"
 
-# GitHub
+# GitHub CLI
+## Telemetry
+set -gx GH_TELEMETRY false
+set -gx DO_NOT_TRACK true
 set -gx GH_DASH_CONFIG "$XDG_CONFIG_HOME/gh/extensions/dash/config.yml"
 
 # Container

--- a/home/dot_config/zsh/zshenv.tmpl
+++ b/home/dot_config/zsh/zshenv.tmpl
@@ -81,6 +81,9 @@ export _ZO_EXCLUDE_DIRS="**/.git/**:**/node_modules/**:**/tmp/**:**/dist/**:**/b
 {{- end }}
 export _ZO_FZF_OPTS="--preview 'eza --tree --long --header --color=always --group-directories-first --hyperlink {} || echo \"No Preview\"' --exit-0"
 
+# GitHub
+export GH_TELEMETRY=false
+export DO_NOT_TRACK=true
 export GH_DASH_CONFIG="$XDG_CONFIG_HOME/gh/extensions/dash/config.yml"
 
 # Container


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Disabled GitHub CLI telemetry and added global DO_NOT_TRACK privacy opt-out.

#### 🎉 New Features

<details>
<summary>feat(shell): disable GitHub CLI telemetry and add DO_NOT_TRACK (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/dfae3376a8ffdd421a4e876422d5edeac5f6bb71">dfae337</a>)</summary>

- Set GH_TELEMETRY to false in fish and zsh environments
- Add DO_NOT_TRACK environment variable to respect privacy
- Update shell configuration templates for consistent environment setup
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1761

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
