### PR TITLE
feat: Readd zizmor config

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -149,6 +149,7 @@ ruby    = "3"
 "aqua:astral-sh/ty"           = "latest" # Python type checker and language server, written in Rust
 "aqua:google/yamlfmt"         = "latest" # YAML formatter
 "aqua:rhysd/actionlint"       = "latest" # YAML Linter for GitHub Actions workflows
+"aqua:zizmorcore/zizmor"      = "latest" # Static analysis for GitHub Actions
 "aqua:golangci/golangci-lint" = "latest" # Go linter aggregator
 "aqua:hadolint/hadolint"      = "latest" # Dockerfile Linter
 "aqua:JohnnyMorganz/StyLua"   = "latest" # Lua Linter

--- a/home/dot_config/nvim/lua/lsp/servers/init.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/init.lua
@@ -21,6 +21,7 @@ return {
   marksman      = require("lsp.servers.marksman"),      -- Markdown
   dockerls      = require("lsp.servers.dockerls"),      -- Docker
   terraformls   = require("lsp.servers.terraformls"),   -- Terraform
+  zizmor        = require("lsp.servers.zizmor"),        -- GitHub Actions
   sqls          = require("lsp.servers.sqls"),          -- SQL
   texlab        = require("lsp.servers.texlab"),        -- LaTex
 }

--- a/home/dot_config/nvim/lua/lsp/servers/zizmor.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/zizmor.lua
@@ -1,0 +1,24 @@
+
+---@type vim.lsp.Config
+return {
+  cmd = { "zizmor", "--lsp" },
+  filetypes = { "yaml" },
+  root_dir = function(bufnr, on_dir)
+    local bufname = vim.api.nvim_buf_get_name(bufnr)
+    local parent  = vim.fs.dirname(bufname)
+    if
+      vim.endswith(parent, "/.github/workflows") or
+      vim.endswith(parent, "/.github/dependabot.yml") or
+      vim.endswith(bufname, "action.yml") then
+      on_dir(parent)
+    end
+  end,
+  init_options = {},
+  capabilities = {
+    workspace = {
+      didChangeWorkspaceFolders = {
+        dynamicRegistration = true,
+      },
+    },
+  },
+}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add zizmor tool to mise
- configure its LSP support in NeoVim for GitHub Actions static analysis.

#### 🎉 New Features

<details>
<summary>feat(nvim): add zizmor lsp server support (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/04e4fda999b959ebcab577475b30f286c8df5aeb">04e4fda</a>)</summary>

- Create zizmor server configuration with workflow-specific root detection
- Register zizmor in lsp server initialization list
- Configure lsp command to run zizmor in lsp mode for yaml files
</details>

<details>
<summary>feat(mise): add zizmor for GitHub Actions static analysis (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b9d9f848df6a3e03b4eb486f3a33f776b92bc142">b9d9f84</a>)</summary>

- Add zizmorcore/zizmor to mise configuration via aqua backend
- Enable static analysis for GitHub Actions workflows
- Track the latest version of zizmor for automated security checks
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1779

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
