### PR TITLE
feat: Add harper config

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -136,6 +136,7 @@ ruby    = "3"
 "github:latex-lsp/texlab"              = "latest" # LaTex
 "github:docker/docker-language-server" = "latest" # Dockerfile, compose.yml
 "github:sqls-server/sqls"              = "latest" # SQL
+"aqua:Automattic/harper/harper-ls"     = "latest" # Offline, privacy-first grammar checker. Fast, open-source, Rust-powered
 
 ## Debugger
 "github:vadimcn/vscode-lldb"           = "latest" # C/C++, Rust, Zig, Swift

--- a/home/dot_config/nvim/lua/lsp/servers/harper_ls.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/harper_ls.lua
@@ -1,0 +1,19 @@
+---@type vim.lsp.Config
+return {
+  cmd = { "harper-ls", "--stdio" },
+  filetypes = require("user.filetypes").lsp.happer,
+  root_markers = { ".git" },
+  single_file_support = true,
+  capabilities = {
+    semanticTokens = { multilineTokenSupport = true },
+  },
+  settings = {
+    ["harper-ls"] = {
+      diagnosticSeverity = "hint",
+      linters = { SpellCheck = true, SentenceCapitalization = true },
+      markdown = { IgnoreLinkTitle = false },
+      dialect = "American",
+      maxFileLength = 120000,
+    },
+  },
+}

--- a/home/dot_config/nvim/lua/lsp/servers/init.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/init.lua
@@ -24,4 +24,5 @@ return {
   zizmor        = require("lsp.servers.zizmor"),        -- GitHub Actions
   sqls          = require("lsp.servers.sqls"),          -- SQL
   texlab        = require("lsp.servers.texlab"),        -- LaTex
+  harper        = require("lsp.servers.harper_ls"),     -- english grammer
 }

--- a/home/dot_config/nvim/lua/user/filetypes.lua
+++ b/home/dot_config/nvim/lua/user/filetypes.lua
@@ -108,6 +108,7 @@ Filetypes.lsp = {
   terraform    = { "terraform", "tf", "terraform-vars", "hcl" },
   tombi        = { "tombi.toml", "pyprojet.toml", ".git" },
   texlab       = { ".latexmkrc", "latexmkrc", ".textlabroot", "textlabroot", "Tectonic.toml" },
+  harper       = { "markdown", "markdown.mdx", "typst", "tex", "plaintex", "text", "gitcommit" },
   sqruff       = { ".sqruff" },
 }
 


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add `harper-ls` grammar checker support to NeoVim LSP configuration
- Integrate `harper-ls` into the environment via `mise` and `aqua`

#### 🎉 New Features

<details>
<summary>feat(nvim): add harper-ls support for grammar checking (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/09107e9480d3daa89d8c898a97c4f1835ddccd4a">09107e9</a>)</summary>

- Create harper_ls configuration with specialized settings and dialect
- Register harper server in LSP initialization list
- Add supported filetypes including markdown, typst, and gitcommit
- Configure diagnostic severity and linter rules for harper-ls
</details>

<details>
<summary>feat(mise): add harper grammar checker (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/5824b4afe8259e66a736d42fa5fa7031620a4371">5824b4a</a>)</summary>

- Add Automattic/harper/harper-ls to mise configuration via aqua backend
- Enable offline, privacy-first grammar checking for the environment
- Provide Rust-powered, fast grammar and spelling assistance
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1781

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
