### PR TITLE
feat: Adopt proxy registry

### DIFF
--- a/home/.chezmoitemplates/common/pnpm/rc.tmpl
+++ b/home/.chezmoitemplates/common/pnpm/rc.tmpl
@@ -10,6 +10,9 @@ strict-dep-builds=true
 # fail if a package's trust level has decreased compared to previous releases.
 trust-policy=no-downgrade
 
+# Takumi Guard (Flatt Security) - supply chain security proxy registry
+registry=https://npm.flatt.tech/
+
 {{- /*
 # -*-mode:sh-*- vim:ft=sh.gotexttmpl
 */ -}}

--- a/home/.chezmoitemplates/common/uv/uv.toml.tmpl
+++ b/home/.chezmoitemplates/common/uv/uv.toml.tmpl
@@ -1,4 +1,10 @@
+# https://docs.astral.sh/uv/reference/settings/#exclude-newer
 exclude-newer = "7 days"
+
+[[index]]
+# https://shisho.dev/docs/ja/t/guard/quickstart/pypi/#setup-anonymous
+url = "https://pypi.flatt.tech/simple/"
+default = true
 
 {{- /*
 # -*-mode:toml-*- vim:ft=toml.gotexttmpl

--- a/home/dot_bunfig.toml.tmpl
+++ b/home/dot_bunfig.toml.tmpl
@@ -9,6 +9,9 @@ save = true
 [install.security]
 scanner = "@socketsecurity/bun-security-scanner"
 
+[install.registry]
+url   = "https://npm.flatt.tech/"
+
 {{- /*
 # -*-mode:toml-*- vim:ft=toml.gotexttmpl
 */ -}}

--- a/home/dot_config/npm/npmrc
+++ b/home/dot_config/npm/npmrc
@@ -7,6 +7,9 @@ progress=true
 min-release-age=7
 ignore-scripts=true
 
+# Takumi Guard (Flatt Security) - supply chain security proxy registry
+registry=https://npm.flatt.tech/
+
 {{- /*
 # -*-mode:dosini-*- vim:ft=dosini
 */ -}}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Adopt Takumi Guard security proxy registry for Python (`uv`)
- Adopt Takumi Guard security proxy registry for Node.js (`npm`, `pnpm`, `bun`)

#### 🎉 New Features

<details>
<summary>feat(uv): adopt Takumi Guard security proxy registry (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/6e249bc5aeb4e3e312c3a34097084715d551ea7c">6e249bc</a>)</summary>

• Configure uv to use Flatt Security's proxy registry for PyPI packages
• Add registry URL https://pypi.flatt.tech/simple/ as the default index
• Enable automated supply chain protection for Python dependencies
</details>

<details>
<summary>feat(node): adopt Takumi Guard security proxy registry (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/0ae054820c59fc4f699b8918b922f7d3670f15c3">0ae0548</a>)</summary>

• Configure npm, pnpm, and bun to use Flatt Security's proxy registry
• Add registry URL https://npm.flatt.tech/ to package manager configs
• Enable automated supply chain protection for Node.js dependencies
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1783

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
