### PR TITLE
feat: Update git hooks config

### DIFF
--- a/hk.local.pkl
+++ b/hk.local.pkl
@@ -1,0 +1,21 @@
+amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+
+local linters = new Mapping<String, Step> {
+  ["mise"]   = Builtins.mise
+  ["shfmt"]  = Builtins.shfmt
+  // ["stylua"] = Builtins.stylua
+  ["biome"]  = Builtins.biome
+}
+
+hooks {
+  ["check"] {
+    steps = linters
+  }
+  ["fix"] {
+    fix   = true
+    steps = linters
+  }
+}
+
+// -*-mode:pkl-*- vim:ft=pkl

--- a/home/dot_config/fish/conf.d/env.fish.tmpl
+++ b/home/dot_config/fish/conf.d/env.fish.tmpl
@@ -46,6 +46,9 @@ set -gx _ZO_EXCLUDE_DIRS "**/.git/**:**/node_modules/**:**/tmp/**:**/dist/**:**/
 {{- end }}
 set -gx _ZO_FZF_OPTS "--preview 'eza --tree --long --header --color=always --group-directories-first --hyperlink {} || echo \"No Preview\"' --exit-0"
 
+# hk: git hooks
+set -gx HK_PKL_BACKEND "pklr" # Enable built-in pkl evaluator
+
 # GitHub CLI
 ## Telemetry
 set -gx GH_TELEMETRY false

--- a/home/dot_config/git/conf.d/hook.conf
+++ b/home/dot_config/git/conf.d/hook.conf
@@ -1,0 +1,39 @@
+# -*-mode:gitconfig-*- vim:ft=gitconfig
+
+# hk config
+[hook "hk-commit-msg"]
+  command = test \"${HK:-1}\" = \"0\" || hk run commit-msg --from-hook \"$@\"
+
+  event = commit-msg
+
+[hook "hk-post-checkout"]
+  command = test \"${HK:-1}\" = \"0\" || hk run post-checkout --from-hook \"$@\"
+  event = post-checkout
+
+[hook "hk-post-commit"]
+  command = test \"${HK:-1}\" = \"0\" || hk run post-commit --from-hook \"$@\"
+  event = post-commit
+
+[hook "hk-post-merge"]
+  command = test \"${HK:-1}\" = \"0\" || hk run post-merge --from-hook \"$@\"
+  event = post-merge
+
+[hook "hk-post-rewrite"]
+  command = test \"${HK:-1}\" = \"0\" || hk run post-rewrite --from-hook \"$@\"
+  event = post-rewrite
+
+[hook "hk-pre-commit"]
+  command = test \"${HK:-1}\" = \"0\" || hk run pre-commit --from-hook \"$@\"
+  event = pre-commit
+
+[hook "hk-pre-push"]
+  command = test \"${HK:-1}\" = \"0\" || hk run pre-push --from-hook \"$@\"
+  event = pre-push
+
+[hook "hk-pre-rebase"]
+  command = test \"${HK:-1}\" = \"0\" || hk run pre-rebase --from-hook \"$@\"
+  event = pre-rebase
+
+[hook "hk-prepare-commit-msg"]
+  command = test \"${HK:-1}\" = \"0\" || hk run prepare-commit-msg --from-hook \"$@\"
+#   event = prepare-commit-msg

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -5,6 +5,7 @@
   path = conf.d/ghq.conf
   path = conf.d/user.conf
   path = conf.d/security.conf
+  path = conf.d/hook.conf
   path = conf.d/hunk.conf
 
 [core]

--- a/home/dot_config/hk/config.pkl.tmpl
+++ b/home/dot_config/hk/config.pkl.tmpl
@@ -30,11 +30,11 @@ local linters = new Mapping<String, Step> {
 
   // Markup languages
   ["rumdl"]        = Builtins.rumdl
-  ["jq"]           = Builtins.jq
-  ["yq"]           = Builtins.yq
-  ["yamlfmt"]      = Builtins.yamlfmt
-  ["tombi"]        = Builtins.tombi
-  ["tombi-format"] = Builtins.tombi_format
+  // ["jq"]           = Builtins.jq
+  // ["yq"]           = Builtins.yq
+  // ["yamlfmt"]      = Builtins.yamlfmt
+  // ["tombi"]        = Builtins.tombi
+  // ["tombi-format"] = Builtins.tombi_format
   // ["pkl"]          = Builtins.pkl
   // ["pkl-format"]   = Builtins.pkl_format
 

--- a/home/dot_config/hk/config.pkl.tmpl
+++ b/home/dot_config/hk/config.pkl.tmpl
@@ -1,0 +1,97 @@
+{{- $version := (output "sh" "-c" "mise tool aqua:jdx/hk | rg 'Installed Versions:' | awk '{print $NF}'") | trim -}}
+amends "package://github.com/jdx/hk/releases/download/v{{ $version }}/hk@{{ $version }}#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v{{ $version }}/hk@{{ $version }}#/Builtins.pkl"
+
+local linters = new Mapping<String, Step> {
+  //--------------------------------------------------
+  // Generic Linters
+  //--------------------------------------------------
+  ["byte-order-marker"]               = Builtins.byte_order_marker
+  ["check_add_large_files"]           = Builtins.check_added_large_files
+  ["check_case_conflict"]             = Builtins.check_case_conflict
+  ["check-executables-have-shebangs"] = Builtins.check_executables_have_shebangs
+  ["check_merge_conflict"]            = Builtins.check_merge_conflict
+  ["check_symlinks"]                  = Builtins.check_symlinks
+  ["detect_private_key"]              = Builtins.detect_private_key
+  // ["editorconfig_checker"]            = Builtins.editorconfig_checker
+  ["end-of-file-fixer"]               = Builtins.newlines
+  ["fix_smart_quotes"]                = Builtins.fix_smart_quotes
+  ["mixed-line-ending"]               = Builtins.mixed_line_ending
+  ["no-commit-to-branch"]             = Builtins.no_commit_to_branch
+  ["trailing-whitespace"]             = Builtins.trailing_whitespace
+
+  //--------------------------------------------------
+  // Third party formatter / linters
+  //--------------------------------------------------
+  ["betterleaks"] = Builtins.betterleaks
+  ["actionlint"]  = Builtins.actionlint
+  ["zizmor"]      = Builtins.zizmor
+  ["pinact"]      = Builtins.pinact
+
+  // Markup languages
+  ["rumdl"]        = Builtins.rumdl
+  ["jq"]           = Builtins.jq
+  ["yq"]           = Builtins.yq
+  ["yamlfmt"]      = Builtins.yamlfmt
+  ["tombi"]        = Builtins.tombi
+  ["tombi-format"] = Builtins.tombi_format
+  // ["pkl"]          = Builtins.pkl
+  // ["pkl-format"]   = Builtins.pkl_format
+
+  // Programming Languages
+  // ["shfmt"]         = Builtins.shfmt
+  // ["stylua"]        = Builtins.stylua
+  // ["biome"]         = Builtins.biome
+  // ["ox_lint"]       = Builtins.ox_lint
+  // ["oxfmt"]         = Builtins.oxfmt
+  // ["deno"]          = Builtins.deno
+  // ["deno-check"]    = Builtins.deno_check
+  // ["cargo-fmt"]     = Builtins.cargo_fmt
+  // ["cargo-clippy"]  = Builtins.cargo_clippy
+  // ["golangci-lint"] = Builtins.golangci_lint
+  // ["ty"]            = Builtins.ty
+  // ["ruff"]          = Builtins.ruff
+  // ["ruff_format"]   = Builtins.ruff_format
+  // ["rubocop"]       = Builtins.rubocop
+
+  // IaC
+  // ["hadolint"]  = Builtins.hadolint
+  // ["terraform"] = Builtins.terraform
+
+  // Grammar / Spell
+  ["typos"]  = Builtins.typos
+  // ["harper"] = Builtins.harper
+}
+
+hooks {
+  ["check"] {
+    steps = linters
+  }
+  ["fix"] {
+    fix   = true
+    steps = linters
+  }
+  // ["commit-msg"] {
+  //   steps = new Mapping<String, Step> {
+  //     ["check-conventional-commit"] = Builtins.check_conventional_commit
+  //   }
+  // }
+  ["pre-commit"] {
+    fix   = false
+    stash = "git"
+    steps = linters
+    // steps = new Mapping<String, Step> {
+    //   ["betterleaks"] = Builtins.betterleaks
+    // }
+  }
+}
+
+jobs       = 4
+fail_fast  = false
+exclude    = List("node_modules", "dist", "build")
+skip_steps = List("slow-test")
+skip_hooks = List("pre-push")
+
+{{- /*
+// -*-mode:pkl-*- vim:ft=pkl.gotexttmpl
+*/ -}}

--- a/home/dot_config/hk/config.pkl.tmpl
+++ b/home/dot_config/hk/config.pkl.tmpl
@@ -6,7 +6,10 @@ local linters = new Mapping<String, Step> {
   //--------------------------------------------------
   // Generic Linters
   //--------------------------------------------------
-  ["byte-order-marker"]               = Builtins.byte_order_marker
+  // By default, chezmoi templates should be written in UTF-8 with no byte order mark
+  ["byte-order-marker"] = (Builtins.byte_order_marker) {
+    exclude = List("**/*.tmpl", "**/*.tmpl.age")
+  }
   ["check_add_large_files"]           = Builtins.check_added_large_files
   ["check_case_conflict"]             = Builtins.check_case_conflict
   ["check-executables-have-shebangs"] = Builtins.check_executables_have_shebangs

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -107,6 +107,7 @@ pnpm    = "11"
 ## Git
 "aqua:o2sh/onefetch"            = "latest" # Repository information
 "aqua:simonwhitaker/gibo"       = "latest" # .gitignore boilerplates
+"aqua:jdx/hk"                   = "latest" # git hooks and project lints
 "github:modem-dev/hunk"         = { version = "latest", bin = "hunk" } # Review-first terminal diff viewer for agentic coders
 "github:gitui-org/gitui"        = "latest" # Blazing 💥 fast terminal-ui for git written in rust 🦀
 "github:max-sixty/worktrunk"    = "latest" # Git worktree management, designed for parallel AI agent workflows

--- a/home/dot_config/zsh/zshenv.tmpl
+++ b/home/dot_config/zsh/zshenv.tmpl
@@ -81,6 +81,9 @@ export _ZO_EXCLUDE_DIRS="**/.git/**:**/node_modules/**:**/tmp/**:**/dist/**:**/b
 {{- end }}
 export _ZO_FZF_OPTS="--preview 'eza --tree --long --header --color=always --group-directories-first --hyperlink {} || echo \"No Preview\"' --exit-0"
 
+# hk: git hooks
+export HK_PKL_BACKEND=pklr # Enable built-in pkl evaluator
+
 # GitHub
 export GH_TELEMETRY=false
 export DO_NOT_TRACK=true

--- a/home/dot_editorconfig.tmpl
+++ b/home/dot_editorconfig.tmpl
@@ -91,6 +91,10 @@ indent_size  = 2
 indent_style    = tab
 max_line_length = 120
 
+[*.{pkl}]
+indent_style = space
+indent_size  = 2
+
 {{- /*
 # -*-mode:editorconfig-*- vim:ft=editorconfig.gotexttmpl
 */ -}}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Integrate `hk` (Housekeeper) tool for managing Git hooks and linting
- Add global and local Pkl configurations for `hk` linters
- Configure `hk` to handle pre-commit, post-merge, and other Git lifecycle events
- Set up formatting rules for `.pkl` files and shell environments
- Exclude chezmoi templates from byte-order-marker (BOM) checks to prevent false positives

#### 🎉 New Features

<details>
<summary>feat(hk): add local pkl configuration for linting and fixing (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/709f508cdc1fad8e1f88941d297b8f38843f99f1">709f508</a>)</summary>

• Add local Pkl configuration for the hk tool
• Define linter mappings for mise, shfmt, and biome
• Configure check and fix hooks to utilize defined linters
• Use Pkl builtins from jdx/hk v1.45.0
</details>

<details>
<summary>feat(hk): add global git hooks configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/9417ed5ab5ded51be24d9e70b17d05be691ce87c">9417ed5</a>)</summary>

• Implement hk configuration using Pkl and Go templates
• Define a comprehensive set of linters for generic, markup, and security checks
• Configure check, fix, and pre-commit hooks with automatic git stashing
• Dynamically resolve the installed hk version via mise
</details>

<details>
<summary>feat(git): add hk based git hooks configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/561ff32144ad114435ba699865b0655e3bd36e10">561ff32</a>)</summary>

• Create hook.conf to integrate hk with various Git lifecycle events
• Update git configuration template to include the new hook definitions
• Implement conditional hook execution based on HK environment variable
• Support pre-commit, post-merge, and other standard Git hooks through hk
</details>

<details>
<summary>feat(shell): add HK_PKL_BACKEND environment variable (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b198d28245ebd1ba8df278091c3ba3e3117a4e4d">b198d28</a>)</summary>

• Enable built-in pkl evaluator for hk tool by setting HK_PKL_BACKEND to pklr
• Configure the environment variable in both fish and zsh shell templates
</details>

#### 🐞 Bug Fixes

<details>
<summary>fix(hk): exclude chezmoi templates from BOM check (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/3571b3ce6a03de27c7a8dcd6a052967773df4f22">3571b3c</a>)</summary>

• Update byte-order-marker linter configuration to ignore template files
• Add exclusion patterns for **/*.tmpl and **/*.tmpl.age
• Prevent false positives on chezmoi templates which must be BOM-free
</details>

#### Other Changes

<details>
<summary>chore(hk): disable various markup and config linters (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/4506daa6aa8a6ab1b60c374bfdd1e6a79634f3b8">4506daa</a>)</summary>

• Comment out jq, yq, and yamlfmt in hk configuration
• Disable tombi and tombi-format steps
• Reduce the scope of automated checks in pre-commit hooks
</details>

<details>
<summary>style(editorconfig): add formatting rules for pkl files (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/0edcf08d147e0b49dd811c6e3d50503d6cc48c90">0edcf08</a>)</summary>

• Set indent_style to space for pkl files
• Set indent_size to 2 for pkl files
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1805

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
