### PR TITLE
chore(nvim): disable jj escape mapping

### DIFF
--- a/home/dot_config/nvim/lua/core/keymap.lua
+++ b/home/dot_config/nvim/lua/core/keymap.lua
@@ -66,7 +66,7 @@ wk.add({
 -- Cursor
 ---------------------------------------------------------------------------
 wk.add({
-  { "jj", "<ESC>", mode = "i", icon = " ", desc = " Return to NORMAL mode" },
+  -- { "jj", "<ESC>", mode = "i", icon = " ", desc = " Return to NORMAL mode" },
   { "kk", "<ESC>", mode = "i", icon = " ", desc = " Return to NORMAL mode" },
 
   { "[[", "<CMD>lua Snacks.words.jump(-vim.v.count1)<CR>", icon = "󰼨 ", desc = "Prev Reference" },


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

• Comment out the 'jj' insert mode escape mapping
• Prevent accidental escapes when typing Jujutsu (jj) commands

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1821

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
