### PR TITLE
feat: Update pnpm & aube config

### DIFF
--- a/home/.chezmoitemplates/common/pnpm/config.yaml.tmpl
+++ b/home/.chezmoitemplates/common/pnpm/config.yaml.tmpl
@@ -3,6 +3,10 @@
 # Mitigate supply chain attacks by by requiring packages to have been published for 7days before they can installed.
 minimumReleaseAge: 10080 # 7 days (in minutes)
 
+# Fail resolution when no version of a dependency satisfies the minimumReleaseAge constraint
+# default: true if explicitly minimumReleaseAge is configured
+minimumReleaseAgeStrict: true
+
 # Exit with a non-zero exit code if any dependencies have unreviewed build scripts (aka postinstall scripts).
 strictDepBuilds: true
 

--- a/home/.chezmoitemplates/common/pnpm/config.yaml.tmpl
+++ b/home/.chezmoitemplates/common/pnpm/config.yaml.tmpl
@@ -14,7 +14,7 @@ strictDepBuilds: true
 trustPolicy: no-downgrade
 
 # Takumi Guard (Flatt Security) - supply chain security proxy registry
-# registry: https://npm.flatt.tech/
+registry: https://npm.flatt.tech/
 
 {{- /*
 # -*-mode:yaml-*- vim:ft=yaml.gotexttmpl

--- a/home/dot_config/aube/config.toml.tmpl
+++ b/home/dot_config/aube/config.toml.tmpl
@@ -35,7 +35,7 @@ verifyStoreIntegrity = true
 trustPolicy = "no-downgrade"
 trustPolicyExclude = []
 
-# registries = ["https://npm.flatt.tech/"]
+registries.default = "https://npm.flatt.tech/"
 
 {{- /*
 # -*-mode:toml-*- vim:ft=toml.gotexttmpl

--- a/home/dot_config/aube/config.toml.tmpl
+++ b/home/dot_config/aube/config.toml.tmpl
@@ -16,6 +16,7 @@ jailBuildExclusions = []
 
 # Mitigate supply chain attacks by by requiring packages to have been published for 7days before they can installed.
 minimumReleaseAge = 10080 # 7 days in minutes
+minimumReleaseAgeExclude = []
 
 # Fail resolution when no version of a dependency satisfies the minimumReleaseAge constraint
 # default: true if explicitly minimumReleaseAge is configured


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Configure default npm registry for aube
- Add minimumReleaseAgeExclude to aube
- Enable custom npm registry for pnpm
- Add minimumReleaseAgeStrict enforcement for pnpm

#### 🎉 New Features

<details>
<summary>feat(aube): configure default npm registry (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/759263751546a74628195e973b94ec51b532324d">7592637</a>)</summary>

- Set default registry to https://npm.flatt.tech/
- Update configuration format to use registries.default
</details>

<details>
<summary>feat(aube): add minimumReleaseAgeExclude (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/72581ecd27d8cc6fa49c8e28a12692d7ab6c3708">72581ec</a>)</summary>

- Add minimumReleaseAgeExclude field to the aube configuration template
- Allow excluding specific dependencies from the minimum release age constraint
</details>

<details>
<summary>feat(pnpm): enable custom npm registry (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/999fd0e8ee6b6e9f45a9b9d22b64b6f57c8531a5">999fd0e</a>)</summary>

- Uncomment registry configuration in pnpm template
- Set registry URL to https://npm.flatt.tech/ for Flatt Tech packages
</details>

<details>
<summary>feat(pnpm): add minimumReleaseAgeStrict (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/dbb4ed59ba5ceef78fd33d6f0ae3e03f5bea2ef7">dbb4ed5</a>)</summary>

- enable strict enforcement of minimumReleaseAge constraint
- fail resolution when no dependency version satisfies the constraint
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1835

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
