### PR TITLE
feat: Update markdown environment

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,4 +1,13 @@
 [global]
+exclude = [
+  ".git/**",
+  ".cache/**",
+  ".agents/**",
+  "node_modules/**",
+  "coverage/**",
+  "vendor/**",
+]
+
 disable = [
   "MD004", # Unordered list style
   "MD010", # Hard tabs

--- a/home/.chezmoidata/lsp.toml
+++ b/home/.chezmoidata/lsp.toml
@@ -2,8 +2,8 @@
 
 [lsp]
 
-[lsp.servers.marksman]
-cmd  = [ "markdman", "server" ]
+[lsp.servers.rumdl]
+cmd  = [ "rumdl", "server" ]
 exts = [ ".md", ".markdown", ".mdx" ]
 
 [lsp.servers.jsonls]

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -130,7 +130,6 @@ ruby    = "3"
 "npm:typescript-language-server"       = "latest" # JavaScript, TypeScript
 "npm:@tailwindcss/language-server"     = "latest" # TailWind CSS
 "aqua:LuaLS/lua-language-server"       = "latest" # Lua
-"aqua:artempyanykh/marksman"           = "latest" # Markdown
 "aqua:tombi-toml/tombi"                = "latest" # TOML
 "aqua:hashicorp/terraform-ls"          = "latest" # Terraform
 "go:golang.org/x/tools/gopls"          = "latest" # Go

--- a/home/dot_config/nvim/lua/lsp/servers/init.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/init.lua
@@ -18,7 +18,7 @@ return {
   jsonls        = require("lsp.servers.jsonls"),        -- JSON
   yamlls        = require("lsp.servers.yamlls"),        -- YAML
   tombi         = require("lsp.servers.tombi"),         -- TOML
-  marksman      = require("lsp.servers.marksman"),      -- Markdown
+  rumdl         = require("lsp.servers.rumdl"),         -- Markdown
   dockerls      = require("lsp.servers.dockerls"),      -- Docker
   terraformls   = require("lsp.servers.terraformls"),   -- Terraform
   zizmor        = require("lsp.servers.zizmor"),        -- GitHub Actions

--- a/home/dot_config/nvim/lua/lsp/servers/rumdl.lua
+++ b/home/dot_config/nvim/lua/lsp/servers/rumdl.lua
@@ -2,8 +2,8 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd          = { "marksman", "server" },
+  cmd          = { "rumdl", "server" },
   filetypes    = { "markdown", "markdown.mdx", "vimwiki" },
-  root_markers = { ".git" },
+  root_markers = { ".rumdl.toml", "rumdl.toml", ".markdownlint.json", ".markdownlint.yaml" },
   single_file_support = true,
 }


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Replace marksman with rumdl for Markdown LSP
- Remove marksman from mise configuration
- Add exclusion patterns to rumdl configuration

#### 🎉 New Features

<details>
<summary>feat(lsp): replace marksman with rumdl for markdown (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/8b8ed102b4fb76b6bc3dd2b0bc9f55aa2abf04ef">8b8ed102</a>)</summary>

- Swap marksman for rumdl in global LSP data configuration
- Update Neovim LSP server initialization to use rumdl
- Configure rumdl with support for markdown, mdx, and vimmwiki
- Add root markers for rumdl.toml and markdownlint configurations
</details>

#### Other Changes

<details>
<summary>chore(mise): remove marksman from tools (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/82b5a7f679120b8c82420a2d4152343da904465c">82b5a7f6</a>)</summary>

- Remove marksman Markdown LSP from mise configuration
- Cleanup unnecessary dependency from the development environment
</details>

<details>
<summary>chore(rumdl): add exclusion patterns to configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/d8e20968ba6bb7deaf9cff419f3a9c5227251b4a">d8e20968</a>)</summary>

- Define directories to be ignored by rumdl
- Include .git, .agents, and node_modules in exclusions
- Optimize analysis by skipping cache and coverage folders
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1837

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
