### PR TITLE
feat: Update nvim appearance

### DIFF
--- a/home/dot_config/nvim/lua/core/appearance.lua
+++ b/home/dot_config/nvim/lua/core/appearance.lua
@@ -45,7 +45,7 @@ vim.opt.showmode   = true
 vim.opt.laststatus = 3
 
 vim.opt.list = true
-vim.opt.listchars = { space = "･", eol = "↴", tab = "»-", trail = "-", nbsp = "%", extends = "⟩", precedes = "⟨" }
+vim.opt.listchars = { space = "･", eol = "↲", tab = "→ ", trail = "•", nbsp = "_", extends = "⟩", precedes = "⟨" }
 
 -- Highlights
 vim.api.nvim_set_hl(0, "SnacksPickerDir",               { fg = palette.cyan })

--- a/home/dot_config/nvim/lua/lsp/config/diagnostics.lua
+++ b/home/dot_config/nvim/lua/lsp/config/diagnostics.lua
@@ -19,6 +19,7 @@ vim.diagnostic.config({
     format = function(d)
       return string.format("%s (%s: %s)", d.message, d.source, d.code)
     end,
+    virt_text_pos = "eol_right_align",
   },
 })
 


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Update Neovim 'listchars' appearance for better visibility
- Configure LSP diagnostic virtual text position to 'eol_right_align'

### 🎉 New Features

<details>
<summary>feat(lsp): update diagnostic virtual text position (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/667b4d5c4c795fe1919bf1d2ce94d5f5abe0e6a2">667b4d5</a>)</summary>

- Set virtual text position to eol_right_align
- Improve visibility of diagnostics by right-aligning them to the end of the line
</details>

<details>
<summary>feat(nvim): update listchars appearance (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/eb46e71a1c1b14a7c017334a87a21eeaff8d8e88">eb46e71</a>)</summary>

- Update end-of-line character from ↴ to ↲
- Change tab character representation to →
- Set trailing whitespace character to •
- Adjust non-breaking space character to _
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1861

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
