### PR TITLE
feat: add sandbox template

### DIFF
--- a/home/.chezmoitemplates/common/ai/sandbox/blacklist.sb.tmpl
+++ b/home/.chezmoitemplates/common/ai/sandbox/blacklist.sb.tmpl
@@ -1,0 +1,83 @@
+(version 1)
+
+;; Allow everything by default
+(allow default)
+
+(deny system-socket)
+(deny iokit-open)
+
+;; =========================================================
+;; Network access
+;; =========================================================
+;; Block network
+(deny network*)
+
+(allow mach-lookup
+  (global-name "com.apple.system.logger")
+  (global-name "com.apple.system.notification_center")
+)
+
+;; =========================================================
+;; File access
+;; =========================================================
+;; Deny write access to system directories
+(deny file-write*
+  (subpath "/System")
+  (subpath "/bin")
+  (subpath "/sbin")
+  (subpath "/usr")
+  (subpath "/Library/Frameworks")
+  (subpath "/Applications")
+)
+
+(deny file-read*
+  ;; Deny access to daemon config
+  (subpath "${HOME}/Library/LaunchAgents")
+  (subpath "${HOME}/Library/Application Support/BraveSoftware/Brave-Browser")
+
+  ;; Deny shell history
+  (subpath "${HOME}/.bash_history")
+  (subpath "${HOME}/.local/zsh/history")
+  (subpath "${HOME}/.local/fish/history")
+
+  ;; .env and variants
+  (regex #".*/\.env(\..*)?$")
+)
+
+;; Deny access to sensitive directories / files
+(deny file-read* file-write*
+  (literal "/etc/passwd")
+  (literal "/etc/shadow"))
+
+  (regex #"^/Users/[^/]+/\.ssh")
+  (regex #"^/Users/[^/]+/\.aws")
+  (regex #"^/Users/[^/]+/\.gcp")
+  (regex #"^/Users/[^/]+/\.gnupg")
+  (regex #"^/Users/[^/]+/\.docker")
+  (regex #"^/Users/[^/]+/\.npmrc")
+
+  (regex #"^/Users/[^/]+/Applications")
+  (regex #"^/Users/[^/]+/Desktop")
+  (regex #"^/Users/[^/]+/Documents")
+  (regex #"^/Users/[^/]+/Downloads")
+  ; (regex #"^/Users/[^/]+/Library")
+  (regex #"^/Users/[^/]+/Movies")
+  (regex #"^/Users/[^/]+/Music")
+  (regex #"^/Users/[^/]+/Pictures")
+  (regex #"^/Users/[^/]+/Public")
+)
+
+;; Deny access to AI agent related config
+(deny file-read* file-write*
+  (regex #"^/Users/[^/]+/\.claude/settings\.json")
+  (regex #"^/Users/[^/]+/\.codex/settings\.json")
+  (regex #"^/Users/[^/]+/\.gemini/settings\.json")
+  (regex #"^/Users/[^/]+/\.config/opencode/.+\.json")
+)
+
+;; Allow write access to specific directories
+(allow file-write*
+)
+{{- /*
+;; -*-mode:scheme-*- vim:ft=scheme.gotexttmpl
+*/ -}}

--- a/home/.chezmoitemplates/common/ai/sandbox/whitelist.sb.tmpl
+++ b/home/.chezmoitemplates/common/ai/sandbox/whitelist.sb.tmpl
@@ -1,0 +1,136 @@
+;; Parameters (`-d KEY=VALUE`)
+;;   WORKSPACE
+;;
+;; Usage:
+;; sandbox-exec -f whitelist.sb -d WORKSPACE=. claude / codex / gemini / opencode
+(version 1)
+
+;; Deny everything by default
+(deny default)
+
+;; =========================================================
+;; System / IPC
+;; =========================================================
+(allow sysctl-read)
+(allow mach-lookup)
+; (allow mach-lookup
+;   (global-name "com.apple.audio.systemsoundserver")
+;   (global-name "com.apple.distributed_notifications@Uv3")
+;   (global-name "com.apple.FontObjectsServer")
+;   (global-name "com.apple.fonts")
+;   (global-name "com.apple.logd")
+;   (global-name "com.apple.lsd.mapdb")
+;   (global-name "com.apple.PowerManagement.control")
+;   (global-name "com.apple.system.logger")
+;   (global-name "com.apple.system.notification_center")
+;   (global-name "com.apple.system.opendirectoryd.libinfo")
+;   (global-name "com.apple.system.opendirectoryd.membership")
+;   (global-name "com.apple.trustd.agent")
+;   (global-name "com.apple.bsd.dirhelper")
+;   (global-name "com.apple.securityd.xpc")
+;   (global-name "com.apple.coreservices.launchservicesd")
+; )
+(allow ipc-posix-shm)
+(allow ipc-posix-shm-read-data)
+(allow ipc-posix-shm-write-create)
+(allow ipc-posix-shm-write-data)
+
+;; =========================================================
+;; Process execution
+;; =========================================================
+(allow process-exec
+  (lietral "/bin/sh")
+  (lietral "/bin/bash")
+  (lietral "/usr/bin/env")
+  (lietral "/usr/bin/osascript")
+  (lietral "/usr/bin/pbcopy")
+  (lietral "/usr/bin/pbpaste")
+  (lietral "/usr/bin/open")
+)
+(allow process-fork)
+(allow process-info-pidinfo)
+(allow process-info-setcontrol)
+(allow signal (target self))
+; (allow signal)
+
+;; =========================================================
+;; Network access
+;; =========================================================
+(allow network-outbound)
+(allow network-inbound)
+; (allow network-inbound
+;   (local tcp "localhost:8000")
+; )
+(allow system-socket)
+
+;; =========================================================
+;; Keychain access
+;; =========================================================
+(allow file-read*
+  (subpath "${HOME}/Library/Keychains")
+  (literal "/Library/Keychains/System.keychain")
+)
+
+(allow file-write*
+  (subpath "${HOME}/Library/Keychains")
+)
+
+;; =========================================================
+;; File access
+;; =========================================================
+;; Allow read access to workspace files
+(allow file-read*
+  (subpath (param "WORKSPACE"))
+)
+
+;; Allow read access to files
+(allow file-read*
+  (literal "/")
+  (subpath "/usr")
+  (subpath "/bin")
+  (subpath "/sbin")
+  (subpath "/usr/local")
+  (subpath "/opt/homebrew")
+  (subpath "/private/etc")
+  (subpath "/private/db")
+  (subpath "/private/var/folders")
+  (subpath "/System")
+  (subpath "/Library")
+
+  (subpath "${HOME}/.config/git")
+)
+
+;; Allow write access to temporary files
+(allow file-read* file-write*
+  (subpath "/tmp")
+  (subpath "/var/folders")
+  (subpath "/private/tmp")
+  (subpath "/private/var/folders")
+)
+
+;; Allow write access to cache directories
+(allow file-write*
+  (subpath "${HOME}/.cache")
+  (subpath "${HOME}/Library/Caches")
+)
+
+;; Allow write access to file descriptor
+(allow file-write*
+  (literal "/dev/stdout")
+  (literal "/dev/stderr")
+  (literal "/dev/null")
+  (literal "/dev/ptmx")
+  (regex #"^/dev/ttys[0-9]*$")
+)
+
+;; Allow access to pseudo files
+(allow file-write-data (subpath "/dev"))
+(allow file-ioctl (subpath "/dev"))
+
+(allow file-read*
+  ; (literal "/usr/local/bin/node")
+)
+
+{{- /*
+;; -*-mode:scheme-*- vim:ft=scheme.gotexttmpl
+*/ -}}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Add macOS sandbox whitelist template for AI agent security
- Add macOS sandbox blacklist template for AI agent security

### 🎉 New Features

<details>
<summary>feat(ai): add macOS sandbox whitelist template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/bd2cd572c1de91b669e3f61726e630154496a8ac">bd2cd57</a>)</summary>

- Implement restrictive whitelist-based sandbox profile
- Enable granular control over system resources and IPC
- Allow controlled network and keychain access for AI agents
- Configure workspace-specific file access via parameters
</details>

<details>
<summary>feat(ai): add macOS sandbox blacklist template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/011b110389876c9288508b49169628e4a7f25f6b">011b110</a>)</summary>

- Implement macOS sandbox profile for AI agent security
- Restrict network access and block access to sensitive system paths
- Prevent access to SSH keys, cloud credentials, and browser data
- Deny read/write access to AI agent configuration files
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1867

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
