### PR TITLE
feat: Update markdown linter

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -26,6 +26,7 @@ disable = [
   "MD045",   # Images should have alternate text (alt text)
   "MD046",   # Use indented code blocks
   "MD060",   # Table column style
+  "MD071",   # Missing blank line after frontmatter
 ]
 
 [MD007]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -9,24 +9,25 @@ exclude = [
 ]
 
 disable = [
-  "MD004", # Unordered list style
-  "MD010", # Hard tabs
-  "MD012", # no-multiple-blanks - Multiple consecutive blank lines
-  "MD013", # line-length - Line length
-  "MD022", # Headings should be surrounded by blank lines
-  "MD024", # no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
-  "MD029", # Ordered list item prefix
-  "MD031", # Fenced code blocks should be surrounded by blank lines
-  "MD032", # Lists should be surrounded by blank
-  "MD033", # no-inline-html - Inline HTML
-  "MD034", # Bare URL used
-  "MD036", # Emphasis used instead of a heading
-  "MD037", # Spaces inside emphasis markers
-  "MD041", # first-line-heading/first-line-h1 - First line in a file should be a top-level heading
-  "MD045", # Images should have alternate text (alt text)
-  "MD060", # Table column style
+  "MD004",   # Unordered list style
+  "MD010",   # Hard tabs
+  "MD012",   # no-multiple-blanks - Multiple consecutive blank lines
+  "MD013",   # line-length - Line length
+  "MD022",   # Headings should be surrounded by blank lines
+  "MD024",   # no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+  "MD029",   # Ordered list item prefix
+  "MD031",   # Fenced code blocks should be surrounded by blank lines
+  "MD032",   # Lists should be surrounded by blank
+  "MD033",   # no-inline-html - Inline HTML
+  "MD034",   # Bare URL used
+  "MD036",   # Emphasis used instead of a heading
+  "MD037",   # Spaces inside emphasis markers
+  "MD041",   # first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+  "MD045",   # Images should have alternate text (alt text)
+  "MD046",   # Use indented code blocks
+  "MD060",   # Table column style
 ]
 
 [MD007]
 indent = 2
-style = "fixed"
+style  = "fixed"


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Disable MD071 rule in markdown linter configuration
- Update markdown linter configuration with MD046 exclusion and improved alignment

### 🎉 New Features

<details>
<summary>feat(lint): disable MD071 in markdown linter configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/ef65518a07ec2cd09a43fe629300fd4e29eaec09">ef65518</a>)</summary>

- Add MD071 to disabled rules in rumdl configuration
- Allow missing blank line after frontmatter in markdown files
</details>

<details>
<summary>feat(lint): update markdown linter configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/e4e721fb976ea3db8ef5061ddf0a0b6512c4a10f">e4e721f</a>)</summary>

- Add MD046 (indented code blocks) to excluded rules in rumdl
- Align configuration keys and values for better readability
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1869

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
