### PR TITLE
feat: Update RTK config

### DIFF
--- a/home/.chezmoitemplates/common/ai/plugins/rtk-config.toml.tmpl
+++ b/home/.chezmoitemplates/common/ai/plugins/rtk-config.toml.tmpl
@@ -1,0 +1,35 @@
+[tracking]
+enabled       = true # enable/disable token tracking
+history_days  = 90   # retention in days (auto-cleanup)
+{{- if eq .chezmoi.os "darwin" }}
+database_path = "{{ .chezmoi.homeDir }}/Library/Caches/rtk/history.db"
+{{- else if eq .chezmoi.os "linux" }}
+database_path = "{{ .chezmoi.homeDir }}/.cache/rtk/history.db"
+{{- end }}
+
+[display]
+colors    = true # colored output
+emoji     = true # use emojis in output
+max_width = 120  # maximum output width
+
+[filters]
+# These apply to file-reading commands (ls, find, grep, cat/rtk read).
+# Paths matching these patterns are excluded from output, keeping noise low.
+ignore_dirs  = [".git", "node_modules", "target", "__pycache__", ".venv", "vendor"]
+ignore_files = ["*.lock", "*.min.js", "*.min.css"]
+
+[tee]
+enabled   = true       # save raw output on failure
+mode      = "failures" # "failures" (default), "always", "never"
+max_files = 20         # rotation: keep last N files
+# directory = "/custom/tee/path"  # optional override
+
+[telemetry]
+enabled = false # anonymous daily ping — see Telemetry & Privacy for full details
+
+[hooks]
+exclude_commands     = []
+transparent_prefixes = []
+{{- /*
+# -*-mode:toml-*- vim:ft=toml.gotexttmpl
+*/ -}}

--- a/home/dot_claude/symlink_RTK.md.tmpl
+++ b/home/dot_claude/symlink_RTK.md.tmpl
@@ -1,0 +1,1 @@
+{{ joinPath .chezmoi.homeDir ".agents" "RTK.md" }}

--- a/home/dot_codex/symlink_RTK.md.tmpl
+++ b/home/dot_codex/symlink_RTK.md.tmpl
@@ -1,0 +1,1 @@
+{{ joinPath .chezmoi.homeDir ".agents" "RTK.md" }}

--- a/home/dot_config/rtk/config.toml.tmpl
+++ b/home/dot_config/rtk/config.toml.tmpl
@@ -1,0 +1,1 @@
+{{ includeTemplate "common/ai/plugins/rtk-config.toml.tmpl" . }}

--- a/home/private_Library/Application Support/rtk/config.toml.tmpl
+++ b/home/private_Library/Application Support/rtk/config.toml.tmpl
@@ -1,0 +1,1 @@
+{{ includeTemplate "common/ai/plugins/rtk-config.toml.tmpl" . }}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Add RTK configuration templates for macOS and Linux
- Link RTK documentation to Claude and Codex workspaces

### 🎉 New Features

<details>
<summary>feat(ai): add RTK documentation symlinks for Claude and Codex (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/71c97e8f5b41b2b7bcb4b21d5d9c985c822690c0">71c97e8</a>)</summary>

- Create symlinks to ~/.agents/RTK.md in Claude and Codex directories
- Provide consistent access to RTK documentation across AI workspaces
</details>

<details>
<summary>feat(rtk): add configuration templates (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/0b2ae144e78a2cd4915d9d176a1fe677e94e8f4b">0b2ae14</a>)</summary>

- Add base RTK configuration template with tracking and display settings
- Configure platform-specific database paths for macOS and Linux
- Implement standard directory and file filters for tool efficiency
- Link base template to XDG config and macOS Application Support paths
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1897

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
