### PR TITLE
feat(ai): Add oh my pi agent

### DIFF
--- a/home/.chezmoidata/ai/agents/pi.toml
+++ b/home/.chezmoidata/ai/agents/pi.toml
@@ -28,6 +28,7 @@ blockImages = false
 enabled = []
 
 [omp.models]
+default   = "opencode/mimo-v2.5-free"
 providers = ["opencode", "openrouter", "ollama-cloud", "huggingface"]
 
   [omp.models.roles]

--- a/home/.chezmoidata/ai/agents/pi.toml
+++ b/home/.chezmoidata/ai/agents/pi.toml
@@ -1,0 +1,41 @@
+pi.theme             = "dark"      # dark|light|<custom theme name>
+pi.thinkingLevel     = "medium"    # off|minimal|low|medium|high|xhigh
+pi.providers.default = "opencode"  # anthropic|openai|google|azure|bedrock|mistral|groq|cerebras|xai|huggingface|kimi|minimax|openrouter|ollama
+pi.models.default    = "auto"
+
+pi.extensions = [
+  # "-extensions/speedreading.ts",
+]
+pi.packages   = [
+  # "npm:context-mode",
+]
+
+pi.prompts = ["./prompts"]
+
+[pi.compaction]
+enabled = true
+
+[pi.terminal]
+clearOnShrink        = true
+showImages           = true
+showTerminalProgress = true
+
+[pi.images]
+autoResize  = true
+blockImages = false
+
+[omp.providers]
+enabled = []
+
+[omp.models]
+providers = ["opencode", "openrouter", "ollama-cloud", "huggingface"]
+
+  [omp.models.roles]
+  default  = "opencode/deepseek-v4-flash-free"
+  smol     = "opencode/big-picke"
+  slow     = "opencode/nemotron-3-ultra-free"
+  vision   = "opencode/mimo-v2.5-free"
+  plan     = "openrouter/nvidia/nemotron-3-ultra-550b-a55b"
+  designer = "openrouter/nvidia/nemotron-3-ultra-550b-a55b"
+  commit   = "opencode/big-picke"
+  task     = "opencode/mimo-v2.5-free"

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -102,21 +102,41 @@ baseUrl = "https:/router.huggingface.co/v1"
 apiKey  = "$HUGGINGFACE_TOKEN"
 
   [[ai.providers.huggingface.models]]
-  id   = "deepseek-ai/deepseek-v4-pro"
-  name = "DeepSeek-V4-Pro"
+  id            = "deepseek-ai/deepseek-v4-pro"
+  name          = "DeepSeek-V4-Pro"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 1048576
+  maxTokens     = 393216
 
   [[ai.providers.huggingface.models]]
-  id   = "moonshotai/kimi-k2.6"
-  name = "Kimi k2.6"
+  id            = "moonshotai/kimi-k2.6"
+  name          = "Kimi k2.6"
+  reasoning     = true
+  input         = ["text", "image"]
+  contextWindow = 262144
+  maxTokens     = 262144
 
   [[ai.providers.huggingface.models]]
-  id   = "minimaxai/minimax-m2.7"
-  name = "MiniMax m2.7"
+  id            = "minimaxai/minimax-m2.7"
+  name          = "MiniMax m2.7"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 204800
+  maxTokens     = 131072
 
   [[ai.providers.huggingface.models]]
-  id   = "zai-org/glm-5.1"
-  name = "GLM-5.1"
+  id            = "zai-org/glm-5.1"
+  name          = "GLM-5.1"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 202752
+  maxTokens     = 131072
 
   [[ai.providers.huggingface.models]]
-  id   = "zai-org/glm-5"
-  name = "GLM-5"
+  id            = "zai-org/glm-5"
+  name          = "GLM-5"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 202752
+  maxTokens     = 131072

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -9,20 +9,36 @@ baseUrl = "https:/opencode.ai/zen/v1"
 apiKey  = "$OPENCODE_API_KEY"
 
   [[ai.providers.opencode.models]]
-  id   = "deepseek-v4-flash-free"
-  name = "DeepSeek V4 Flash"
+  id            = "deepseek-v4-flash-free"
+  name          = "DeepSeek V4 Flash"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 200000
+  maxTokens     = 128000
 
   [[ai.providers.opencode.models]]
-  id   = "mimo-v2.5-free"
-  name = "Mimo v2.5"
+  id            = "mimo-v2.5-free"
+  name          = "Mimo v2.5"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 1048576
+  maxTokens     = 131072
 
   [[ai.providers.opencode.models]]
-  id   = "nemotron-3-ultra-free"
-  name = "NVIDIA Nemotron 3 Ultra"
+  id            = "nemotron-3-ultra-free"
+  name          = "NVIDIA Nemotron 3 Ultra"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 1000000
+  maxTokens     = 128000
 
   [[ai.providers.opencode.models]]
-  id   = "big-pickle"
-  name = "Big Pickle"
+  id            = "big-pickle"
+  name          = "Big Pickle"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 200000
+  maxTokens     = 32000
 
 ################################################################################
 # Openrouter

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -53,6 +53,20 @@ baseUrl = "https:/ollama.com/v1"
 apiKey  = "$OPENROUTER_API_KEY"
 
   [[ai.providers.ollama.models]]
+  id            = "glm-5.2:cloud"
+  name          = "GLM 5.2"
+  reasoning     = true
+  contextWindow = 1000000
+  maxTokens     = 131072
+
+  [[ai.providers.ollama.models]]
+  id            = "kimi-k2.7-code:cloud"
+  name          = "Kimi K2.7 Code"
+  reasoning     = true
+  contextWindow = 262144
+  maxTokens     = 65536
+
+  [[ai.providers.ollama.models]]
   id            = "glm-5.1:cloud"
   name          = "GLM 5.1"
   reasoning     = true

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -33,6 +33,14 @@ apiKey  = "$OPENCODE_API_KEY"
   maxTokens     = 128000
 
   [[ai.providers.opencode.models]]
+  id            = "north-mini-code-free"
+  name          = "North Mini Code"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 256000
+  maxTokens     = 64000
+
+  [[ai.providers.opencode.models]]
   id            = "big-pickle"
   name          = "Big Pickle"
   reasoning     = true

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -35,10 +35,6 @@ baseUrl = "https:/openrouter.ai/api/v1"
 apiKey  = "$OPENROUTER_API_KEY"
 
   [[ai.providers.openrouter.models]]
-  id   = "moonshotai/kimi-k2.6:free"
-  name = "Kimi K2.6"
-
-  [[ai.providers.openrouter.models]]
   id   = "nvidia/nemotron-3-ultra-550b-a55b:free"
   name = "NVIDIA Nemotron 3 Ultra"
 

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -59,12 +59,20 @@ baseUrl = "https:/openrouter.ai/api/v1"
 apiKey  = "$OPENROUTER_API_KEY"
 
   [[ai.providers.openrouter.models]]
-  id   = "nvidia/nemotron-3-ultra-550b-a55b:free"
-  name = "NVIDIA Nemotron 3 Ultra"
+  id            = "nvidia/nemotron-3-ultra-550b-a55b:free"
+  name          = "NVIDIA Nemotron 3 Ultra"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 1000000
+  maxTokens     = 65536
 
   [[ai.providers.openrouter.models]]
-  id   = "nvidia/nemotron-3-super-120b-a12b"
-  name = "NVIDIA Nemotron 3 Super"
+  id            = "nvidia/nemotron-3-super-120b-a12b"
+  name          = "NVIDIA Nemotron 3 Super"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 262144
+  maxTokens     = 262142
 
 ################################################################################
 # Ollama Cloud

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -82,7 +82,7 @@ name    = "Ollama Cloud"
 api     = "openai-completions"
 npm     = "@ai-sdk/openai-compatible"
 baseUrl = "https:/ollama.com/v1"
-apiKey  = "$OPENROUTER_API_KEY"
+apiKey  = "$OLLAMA_API_KEY"
 
   [[ai.providers.ollama.models]]
   id            = "glm-5.2:cloud"

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -59,25 +59,22 @@ apiKey  = "$OPENROUTER_API_KEY"
   [[ai.providers.ollama.models]]
   id            = "glm-5.1:cloud"
   name          = "GLM 5.1"
-  reasoning      = true
-  input         = ["text"]
-  contextWindow = 131072
+  reasoning     = true
+  contextWindow = 202752
   maxTokens     = 131072
 
   [[ai.providers.ollama.models]]
   id            = "kimi-k2.6:cloud"
   name          = "Kimi k2.6"
-  reasoning      = true
-  input         = ["text"]
-  contextWindow = 131072
-  maxTokens     = 131072
+  reasoning     = true
+  contextWindow = 262144
+  maxTokens     = 32768
 
   [[ai.providers.ollama.models]]
   id            = "minimax-m3:cloud"
   name          = "MiniMax m3"
-  reasoning      = true
-  input         = ["text"]
-  contextWindow = 131072
+  reasoning     = true
+  contextWindow = 1024000
   maxTokens     = 131072
 
   [[ai.providers.ollama.models]]

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -213,7 +213,9 @@ ruby    = "3"
 "github:ogulcancelik/herdr"               = { version = "latest" }
 "aqua:anomalyco/opencode"                 = { version = "latest", minimum_release_age = "2d" }
 "aqua:google-antigravity/antigravity-cli" = { version = "latest" }
+"npm:@earendil-works/pi-coding-agent"     = { version = "latest", minimum_release_age = "2d" }
 "npm:@google/gemini-cli"                  = { version = "latest", minimum_release_age = "2d" }
+"github:can1357/oh-my-pi"                 = { version = "latest" }
 
 ### AI utility
 "aqua:rtk-ai/rtk"            = "latest" # High-performance CLI proxy that reduces LLM token consumption by 60-90%

--- a/home/dot_omp/agent/AGENTS.md.tmpl
+++ b/home/dot_omp/agent/AGENTS.md.tmpl
@@ -1,0 +1,19 @@
+# AI Agent Guidelines
+
+This file contains the foundational principles and guidelines for the AI assistant in this workspace.
+
+## Core Principles
+
+{{ includeTemplate "common/ai/instructions/principles.md" . }}
+## Security Policy
+
+{{ includeTemplate "common/ai/instructions/security.md" . }}
+## Coding Standards
+
+{{ includeTemplate "common/ai/instructions/coding.md" . }}
+## Tools and CLI
+
+{{ includeTemplate "common/ai/instructions/tools.md" . }}
+{{- /*<!--
+mode:markdown vim:ft=markdown
+-->*/ -}}

--- a/home/dot_omp/agent/config.yml.tmpl
+++ b/home/dot_omp/agent/config.yml.tmpl
@@ -18,6 +18,7 @@ statusLine:
   showHookStatus: true
 defaultThinkingLevel: auto
 thinkingLevel: low
+defaultModel: {{ .omp.models.default }}
 modelRoles:
   default: {{ .omp.models.roles.default }}
   smol: {{ .omp.models.roles.smol }}

--- a/home/dot_omp/agent/config.yml.tmpl
+++ b/home/dot_omp/agent/config.yml.tmpl
@@ -17,17 +17,8 @@ statusLine:
   sessionAccent: true
   showHookStatus: true
 defaultThinkingLevel: auto
-thinkingLevel: low
-defaultModel: {{ .omp.models.default }}
-modelRoles:
-  default: {{ .omp.models.roles.default }}
-  smol: {{ .omp.models.roles.smol }}
-  slow: {{ .omp.models.roles.slow }}
-  vision: {{ .omp.models.roles.vision }}
-  plan: {{ .omp.models.roles.plan }}
-  designer: {{ .omp.models.roles.designer }}
-  commit: {{ .omp.models.roles.commit }}
-  task: {{ .omp.models.roles.task }}
+{{ dict "defaultThinkingLevel" .omp.models.default | toYaml | trim }}
+{{ dict "modelRoles" .omp.models.roles | toYaml | trim }}
 modelProviderOrder: {{ .omp.models.providers | toYaml | nindent 2 }}
 compaction:
   enabled: true

--- a/home/dot_omp/agent/config.yml.tmpl
+++ b/home/dot_omp/agent/config.yml.tmpl
@@ -1,0 +1,35 @@
+enableInstallTelemetry: false
+theme:
+  dark: dark-tokyo-night
+  light: light-cyberpunk
+terminal:
+  showTerminalProgress: true
+  showImages: true
+tui:
+  hyperlinks: auto
+symbolPreset: nerd
+display:
+  shimmer: kitt
+  showTokenUsage: true
+statusLine:
+  separator: full
+  preset: full
+  sessionAccent: true
+  showHookStatus: true
+defaultThinkingLevel: auto
+thinkingLevel: low
+modelRoles: {{ .omp.models.roles | toYaml | nindent 2 -}}
+modelProviderOrder: {{ .omp.models.providers | toYaml | nindent 2 }}
+compaction:
+  enabled: true
+  strategy: handoff          # "context-full" | "handoff" | "off"
+  reserveTokens: 16384       # headroom kept under the context window
+  keepRecentTokens: 20000    # target size of the verbatim tail
+  autoContinue: true         # schedule continuation after threshold compaction
+  idleEnabled: true          # run maintenance while idle
+  thresholdPercent: -1       # explicit % override; -1 = auto
+  thresholdTokens: -1        # explicit token override; -1 = auto
+extensions:
+{{- /*
+# -*-mode:yaml-*- vim:ft=yaml.gotexttmpl
+*/ -}}

--- a/home/dot_omp/agent/config.yml.tmpl
+++ b/home/dot_omp/agent/config.yml.tmpl
@@ -18,7 +18,15 @@ statusLine:
   showHookStatus: true
 defaultThinkingLevel: auto
 thinkingLevel: low
-modelRoles: {{ .omp.models.roles | toYaml | nindent 2 -}}
+modelRoles:
+  default: {{ .omp.models.roles.default }}
+  smol: {{ .omp.models.roles.smol }}
+  slow: {{ .omp.models.roles.slow }}
+  vision: {{ .omp.models.roles.vision }}
+  plan: {{ .omp.models.roles.plan }}
+  designer: {{ .omp.models.roles.designer }}
+  commit: {{ .omp.models.roles.commit }}
+  task: {{ .omp.models.roles.task }}
 modelProviderOrder: {{ .omp.models.providers | toYaml | nindent 2 }}
 compaction:
   enabled: true

--- a/home/dot_omp/agent/models.yml.tmpl
+++ b/home/dot_omp/agent/models.yml.tmpl
@@ -1,0 +1,4 @@
+{{ dict "providers" .ai.providers | toYaml }}
+{{- /*
+# -*-mode:yaml-*- vim:ft=yaml.gotexttmpl
+*/ -}}

--- a/home/dot_omp/agent/symlink_skills.tmpl
+++ b/home/dot_omp/agent/symlink_skills.tmpl
@@ -1,0 +1,1 @@
+{{ joinPath .chezmoi.homeDir ".agents" "skills" }}


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Simplify model configuration in agent template
- Correct api key for ollama cloud
- Add skills symlink path for OMP
- Add models.yml template for OMP
- Add AGENTS.md template for OMP
- Add metadata to OpenRouter models
- Add north-mini-code-free model
- Add metadata to OpenCode models
- Add model specs for HuggingFace providers
- Add GLM 5.2 and Kimi K2.7 Code models
- Remove deprecated kimi-k2.6 free model
- Update Ollama model context windows
- Add default model configuration
- Explicitly define model roles in config template
- Add Oh My Pi agent configuration template
- Add initial configuration for Pi and OMP agents
- Add pi-coding-agent and oh-my-pi tools

### 🎉 New Features

<details>
<summary>feat(mise): add pi-coding-agent and oh-my-pi tools (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/9773d5a3e8d7a2a147ab2ef9dba020d2254393bd">9773d5a</a>)</summary>

- Add @earendil-works/pi-coding-agent via npm in mise
- Add can1357/oh-my-pi via github in mise
- Update mise configuration template with new tool definitions
</details>

<details>
<summary>feat(ai): add initial configuration for pi and omp agents (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/36a6ec08abbf79ed2616781a8b06397c3f797b1e">36a6ec0</a>)</summary>

- Create pi.toml for AI agent settings
- Configure providers and default model roles
- Enable compaction and terminal enhancements
- Define model mappings for specific roles (smol, slow, vision, etc.)
</details>

<details>
<summary>feat(omp): add oh my pi agent configuration template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/31c91c729fd486adb8507633c33932000465f153">31c91c7</a>)</summary>

- Initialize configuration template for Oh My Pi (OMP) agent
- Configure UI themes, terminal behavior, and symbol presets
- Enable token compaction with handoff strategy for context management
- Integrate template variables for model roles and provider order
</details>

<details>
<summary>feat(omp): add default model configuration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/a6a1d74164a276a5d38c863dd356d095b6e44a2e">a6a1d74</a>)</summary>

- Set default model to opencode/mimo-v2.5-free in pi.toml
- Add modelRoles configuration in config.yml.tmpl for default and smol roles
- Enable template variables for dynamic model selection
</details>

<details>
<summary>feat(ai): add GLM 5.2 and Kimi K2.7 Code models (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/8de97e6c6f879a3aa297db388928e7c1e16c62dc">8de97e6</a>)</summary>

- Add GLM 5.2 with 1M context window and 131K max tokens
- Add Kimi K2.7 Code with 262K context window and 65K max tokens
</details>

<details>
<summary>feat(ai): add model specs for HuggingFace providers (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/49c74a094e7114e7d3969c22a9cd122d7db4c730">49c74a0</a>)</summary>

- Add reasoning, input types, context window, and max tokens for 5 models
- Specify text input for DeepSeek-V4-Pro, MiniMax m2.7, GLM-5.1, GLM-5
- Set Kimi k2.6 with text+image input and 262K context window
</details>

<details>
<summary>feat(providers): add north-mini-code-free model (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/462cf674d694b811cac1f2cb65f088e881f2e874">462cf67</a>)</summary>

- Add new model with 256K context window and 64K max tokens
- Enable reasoning and text input for the model
- Register under opencode provider configuration
</details>

<details>
<summary>feat(providers): add metadata to openrouter models (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/0ee37f24b7b9f90611836ee4992c118c5c76db08">0ee37f2</a>)</summary>

- Add reasoning, input, contextWindow, and maxTokens to Nemotron 3 Ultra/Super
- Set Ultra with 1M context window and 64K max tokens
- Set Super with 262K context window and 262K max tokens
</details>

<details>
<summary>feat(agent): add AGENTS.md template for omp (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/1690f3eda518cdeacb91ad1e885802aaa4d4b170">1690f3e</a>)</summary>

- Create AGENTS.md.tmpl with core principles, security, and coding standards
- Include shared templates for AI instructions via chezmoi template
- Configure markdown mode with vim modeline
</details>

<details>
<summary>feat(agent): add models.yml template for omp (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7e73c5c38b6c07ed3d4d52434418f369488e2354">7e73c5c</a>)</summary>

- Create models.yml.tmpl to expose AI providers config as YAML
- Use chezmoi template to render providers data
- Configure yaml mode with vim modeline
</details>

<details>
<summary>feat(agent): add skills symlink path for omp (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/23b13df7196623a055f31087ce6825f6086cf328">23b13df</a>)</summary>

- Create symlink_skills.tmpl pointing to global .agents/skills directory
- Use chezmoi template to resolve home directory path
</details>

### 🐞 Bug Fixes

<details>
<summary>fix(ai): update Ollama model context windows (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/5ca96cbe88487fded89f38a1dd6ef4ecb74734f0">5ca96cb</a>)</summary>

- Remove redundant input type specification from model configs
- Correct contextWindow for kimi-k2.6 to 202752 and minimax-m3 to 1024000
- Adjust maxTokens for kimi-k2.6 to 32768
</details>

<details>
<summary>fix(providers): correct api key for ollama cloud (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7d206b3767c3c40a608afb67e8d4aa7c33f77eda">7d206b3</a>)</summary>

- Fix OPENROUTER_API_KEY to OLLAMA_API_KEY in ollama provider config
</details>

### Other Changes

<details>
<summary>refactor(omp): simplify model configuration in agent template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b080fb3e461d6d439301b99a8eebae159d71fd05">b080fb3</a>)</summary>

- Use dict and toYaml to dynamically generate model roles from data
- Replace individual model role mappings with a single configuration block
- Streamline default thinking level assignment using template functions
</details>

<details>
<summary>refactor(omp): explicitly define model roles in config template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/4d16711f913a1abff84a9d6596b739b4cea0934e">4d16711</a>)</summary>

- Replace dynamic YAML conversion with explicit role definitions
- List each role type individually for better template readability
- Roles: default, smol, slow, vision, plan, designer, commit, task
</details>

<details>
<summary>chore(ai): remove deprecated kimi-k2.6 free model (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/6c5226dd0a21c4144bb369e0a6f5d1d693640574">6c5226d</a>)</summary>

- Remove moonshotai/kimi-k2.6:free from OpenRouter providers
- Model no longer available as free tier
</details>

<details>
<summary>chore(providers): add metadata to opencode models (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/92e79537089f29f86177f3567dab2e37640b949b">92e7953</a>)</summary>

- Add reasoning, input, contextWindow, and maxTokens per model
- Define context window sizes (200K-1M) and token limits per model
- Specify supported input types for each opencode provider model
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1920

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
