### PR TITLE
feat: Update OpenCode config

### DIFF
--- a/home/.chezmoidata/ai/agents/opencode.toml
+++ b/home/.chezmoidata/ai/agents/opencode.toml
@@ -5,19 +5,21 @@ opencode.providers.enabled = ["opencode", "openrouter", "ollama-cloud", "hugging
 
 [opencode.models]
 ultra   = [
-  "opencode/minimax-m3-free",
+  "ollama-cloud/glm-5.2:cloud",
+  "ollama-cloud/kimi-k2.7-code:cloud",
   "ollama-cloud/minimax-m3:cloud",
 
-  "openrouter/moonshotai/kimi-k2.6:free",
-  "huggingface/moonshotai/kimi-k2.6",
   "ollama-cloud/kimi-k2.6:cloud",
+  "huggingface/moonshotai/kimi-k2.6",
+  "opencode/deepseek-v4-flash-free",
 
   "opencode/qwen-3.6-plus-free",
   "huggingface/deepseek-ai/deepseek-v4-pro",
   "opencode/deepseek-v4-flash-free",
 ]
 elite   = [
-  "opencode/qwen-3.6-plus-free",
+  "opencode/deepseek-v4-flash-free",
+  "ollama-cloud/kimi-k2.6:cloud",
   "opencode/mimo-v2.5-free",
   "opencode/nemotron-3-ultra-free",
   "huggingface/minimaxai/minimax-m2.7",

--- a/home/dot_config/opencode/commands/git-changelog.md.tmpl
+++ b/home/dot_config/opencode/commands/git-changelog.md.tmpl
@@ -1,0 +1,12 @@
+---
+description: Generate current branch changelog
+---
+# Chagelog Generator
+
+You are an AI assistant programmed to perform meticulous, context-aware changelog generations using the tools available in the OpenCode. Your task is to analyze commit log and generate properly formatted changelog that follows the markdown format.
+
+{{- includeTemplate "common/ai/commands/git/changelog.md" . }}
+
+{{- /*<!--
+mode:markdown vim:ft=markdown
+-->*/ -}}

--- a/home/dot_config/opencode/commands/git-commit.md.tmpl
+++ b/home/dot_config/opencode/commands/git-commit.md.tmpl
@@ -1,0 +1,12 @@
+---
+description: Generate terse conventional commit message for staged changes using caveman-style (≤72 char subject, why over what).
+argument-hint: <commit-message-context>
+---
+# Conventional Commit Generator
+
+You are an AI assistant programmed to perform meticulous, context-aware commit message generations using the tools available in the OpenCode. Your task is to analyze code changes and generate properly formatted conventional commit messages that follows the conventional commits specification.
+
+{{- includeTemplate "common/ai/commands/git/commit.md" . }}
+{{- /*<!--
+mode:markdown vim:ft=markdown
+-->*/ -}}

--- a/home/dot_config/opencode/config.json.tmpl
+++ b/home/dot_config/opencode/config.json.tmpl
@@ -7,7 +7,7 @@
   "small_model": {{ index .opencode.models.elite 0 | quote }},
   {{/* Global plugins */ -}}
   "plugin": [
-    "superpowers@git+https://github.com/obra/superpowers.git",
+    // "superpowers@git+https://github.com/obra/superpowers.git",
     "@tarquinen/opencode-dcp@latest",
     "./plugins/damage-control.ts",
     "./plugins/notification.ts",

--- a/home/dot_config/opencode/config.json.tmpl
+++ b/home/dot_config/opencode/config.json.tmpl
@@ -112,7 +112,7 @@
     },
   },
   {{/* Agent Configurations */ -}}
-  "default_agent": "Sisyphus",
+  "default_agent": "build",
   "agent": {
     {{/* Builtin Primary Agents */ -}}
     "plan": { "disable": false },


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Change default agent to build
- Comment out superpowers plugin
- Update AI model tiers and providers
- Add git changelog and commit commands

### 🎉 New Features

<details>
<summary>feat(opencode): update AI model tiers and providers (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/c062e716">c062e716</a>)</summary>

- Replace deprecated models with newer alternatives across fast/elite tiers
- Add ollama-cloud/glm-5.2, kimi-k2.7-code, and opencode/deepseek-v4-flash
- Reorder model priority in elite tier for optimal fallback behavior
</details>

<details>
<summary>feat(opencode): add git changelog and commit commands (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/fc5769bb">fc5769bb</a>)</summary>

- Create git-changelog command template for branch changelog generation
- Create git-commit command template for conventional commit messages
- Both delegate to shared common templates via includeTemplate
</details>

### Other Changes

<details>
<summary>chore(opencode): change default agent to build (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/3c745e0b">3c745e0b</a>)</summary>

- Update default_agent setting from Sisyphus to build
- Align default with the new primary agent workflow
</details>

<details>
<summary>chore(opencode): comment out superpowers plugin (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/d2671de5">d2671de5</a>)</summary>

- Disable superpowers external plugin in config
- Keep the reference as a comment for future re-enablement
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1922

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
