### PR TITLE
feat: Update OpenCode config

### DIFF
--- a/home/dot_config/opencode/README.md
+++ b/home/dot_config/opencode/README.md
@@ -6,12 +6,10 @@
 opencode/
 ├── agents/                # Custom specialized agent collection
 ├── commands/              # Custom Slash Commands
-├── instructions/          # Instruction reference
 ├── plugins/               # Plugins for extending OpenCode
 ├── skills/                # Custom Skills
 ├── AGENTS.md              # Global Shared Context
 ├── config.json            # Main configuration (theme, plugins, models, LSP, MCP)
-├── oh-my-opencode.json    # Oh-my-OpenCode config file
 └── README.md              # This file
 ```
 
@@ -41,8 +39,8 @@ opencode/
 
 | Command          | Description                                               |
 | :--------------- | :-------------------------------------------------------- |
-| `/git:commit`    | Generate conventional commit message from staged changes. |
-| `/git:changelog` | Generaete current branch changelog.                       |
+| `/git-commit`    | Generate conventional commit message from staged changes. |
+| `/git-changelog` | Generaete current branch changelog.                       |
 
 > Docs: [https://opencode.ai/docs/commands](https://opencode.ai/docs/commands)
 

--- a/home/dot_config/opencode/agents/auditor.md.tmpl
+++ b/home/dot_config/opencode/agents/auditor.md.tmpl
@@ -7,14 +7,16 @@ temperature: 0.1
 permission:
   edit: deny
   read:
-    "*": deny
+    "*": allow
     ".github/**": allow
   external_directory: deny
   bash:
-    "npm audit*": allow
+    "npm audit*": deny
     "pnpm audit*": allow
-    "yarn audit*": allow
-    "pip-audit*": allow
+    "bun audit": allow
+    "yarn audit*": deny
+    "pip-audit*": deny
+    "uv audit*": allow
     "*": ask
   webfetch: allow
 ---

--- a/home/dot_config/opencode/config.json.tmpl
+++ b/home/dot_config/opencode/config.json.tmpl
@@ -124,13 +124,12 @@
     "plan": { "disable": false },
     "build": { "disable": false },
     {{/* Builtin Subagents */ -}}
-    "general": { "disable": false },
-    "explore": { "disable": false },
-    "scout": { "disable": false },
+    "general": { "disable": true },
+    "explore": { "disable": true },
+    "scout": { "disable": true },
     {{/* Custom Agents */ -}}
     "auditor": { "disable": false },
-    "translator": { "disable": false },
-    "triager": { "disable": false }
+    "translator": { "disable": false }
   },
   {{/* Formatter Configurations */ -}}
   "formatter": {

--- a/home/dot_config/opencode/config.json.tmpl
+++ b/home/dot_config/opencode/config.json.tmpl
@@ -18,16 +18,9 @@
   "instructions": ["AGENTS.md", "CLAUDE.md"],
   {{/* Global Permissions */ -}}
   "permission": {
-    "list": "allow",
-    "grep": "allow",
-    "glob": "allow",
-    "lsp": "allow",
     "todoread": "allow",
     "todowrite": "allow",
-    "question": "allow",
-    "webfetch": "allow",
-    "task": { "*": "allow" },
-    "skill": { "*": "ask" },
+    "websearch": "allow",
     {{- $read := dict -}}
     {{- range .agents.permissions.read.allow -}}{{- $read = set $read . "allow" -}}{{- end }}
     {{- range .agents.permissions.read.ask -}}{{- $read = set $read . "ask" -}}{{- end }}
@@ -42,8 +35,7 @@
     {{- range .agents.permissions.bash.deny -}}{{- $bash = set $bash . "deny" -}}{{- end }}
     "read": {{ $read | toPrettyJson | indent 4 | trim }},
     "edit": {{ $edit | toPrettyJson | indent 4 | trim }},
-    "bash": {{ $bash | toPrettyJson | indent 4 | trim }},
-    "external_directory": {}
+    "bash": {{ $bash | toPrettyJson | indent 4 | trim }}
   },
   {{/* Compaction config */ -}}
   "compaction": { "auto": true, "prune": true },

--- a/home/dot_config/opencode/config.json.tmpl
+++ b/home/dot_config/opencode/config.json.tmpl
@@ -238,21 +238,6 @@
       "disabled": false,
       "extensions": [".tf", ".hcl"]
     }
-  },
-  {{/* MCP Server Configurations */ -}}
-  "mcp": {
-    "context7": {
-      "type": "remote",
-      "url": "https://mcp.context7.com/mcp",
-      "headers": { "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}" },
-      "enabled": true
-    },
-    "grep_app": {
-      "type": "remote",
-      "url": "https://mcp.grep.app",
-      "headers": {},
-      "enabled": true
-    }
   }
 }
 {{- /*

--- a/opencode.json
+++ b/opencode.json
@@ -44,5 +44,19 @@
       "permission": { "edit": "deny", "gh_grep_*": "allow" }
     },
     "translator": { "disable": false },
+  },
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": { "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}" },
+      "enabled": true
+    },
+    "grep_app": {
+      "type": "remote",
+      "url": "https://mcp.grep.app",
+      "headers": {},
+      "enabled": true
+    }
   }
 }

--- a/opencode.json
+++ b/opencode.json
@@ -14,5 +14,35 @@
     "skill": { "*": "ask" },
     "task": { "*": "allow" },
     "external_directory": { "*": "ask" }
+  },
+  "default_agent": "build",
+  "agent": {
+    "plan": { "disable": true },
+    "build": {
+      "disable": false,
+      "permission": {
+        "memory_*": "allow",
+        "context7_*": "allow",
+        "gh_grep_*": "allow"
+      }
+    },
+    "general": {
+      "disable": false,
+      "permission": {
+        "memory_*": "allow",
+        "context7_*": "allow",
+        "gh_grep_*": "allow"
+      }
+    },
+    "explore": {
+      "disable": false,
+      "permission": { "edit": "deny", "gh_grep_*": "allow" }
+    },
+    "scout": { "disable": true },
+    "auditor": {
+      "disable": false,
+      "permission": { "edit": "deny", "gh_grep_*": "allow" }
+    },
+    "translator": { "disable": false },
   }
 }

--- a/opencode.json
+++ b/opencode.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "compaction": { "auto": true, "prune": true },
   "watcher": {
-    "ignore": [".git/**", ".jj/**", "**/*.log", "rumdl_cache", "antigravitycli"]
+    "ignore": [".git/**", ".jj/**", "**/*.log", ".rumdl_cache", ".claude", ".codex", ".antigravitycli", ".opencode"]
   },
   "permission": {
     "list": "allow",

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "compaction": { "auto": true, "prune": true },
+  "watcher": {
+    "ignore": [".git/**", ".jj/**", "**/*.log", "rumdl_cache", "antigravitycli"]
+  },
+  "permission": {
+    "list": "allow",
+    "grep": "allow",
+    "glob": "allow",
+    "lsp": "allow",
+    "question": "allow",
+    "webfetch": "allow",
+    "skill": { "*": "ask" },
+    "task": { "*": "allow" },
+    "external_directory": { "*": "ask" }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -43,7 +43,7 @@
       "disable": false,
       "permission": { "edit": "deny", "gh_grep_*": "allow" }
     },
-    "translator": { "disable": false },
+    "translator": { "disable": false }
   },
   "mcp": {
     "context7": {


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed
- Migrate static configurations from chezmoi template to opencode.json
- Update watcher ignore patterns for agent data directories
- Update auditor agent permissions for modern tools
- Update README directory tree and command references

### Other Changes

<details>
<summary>refactor(opencode): move tool permissions to static config (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/3602d579">3602d579</a>)</summary>

- Extract static tool permissions from chezmoi template into standalone opencode.json
- Simplify template to only manage dynamic/conditional permissions
- Remove duplicate permission declarations from config template
</details>

<details>
<summary>refactor(opencode): migrate agent config to static file (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/d8e2db6d">d8e2db6d</a>)</summary>

- Move agent definitions and permissions from chezmoi template into opencode.json
- Disable plan agent — use grill-with-docs or superpowers instead
- Disable general, explore, and scout agents in template
- Add per-agent permission blocks for build, general, explore, and auditor agents
</details>

<details>
<summary>refactor(opencode): move MCP server config to static file (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/bce44468">bce44468</a>)</summary>

- Migrate context7 and grep_app MCP server definitions from chezmoi template into opencode.json
- Remove now-redundant MCP configuration block from template
</details>

<details>
<summary>chore(opencode): update auditor agent permissions for modern tools (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/3c454a90">3c454a90</a>)</summary>

- Switch default directory permission from deny to allow
- Add bun and uv audit to allowed commands
- Remove npm, yarn, and pip-audit from allowed audit commands
</details>

<details>
<summary>chore(opencode): update watcher ignore patterns (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/144dff67">144dff67</a>)</summary>

- Add .claude, .codex, .opencode directories to watcher ignore list
- Fix rumdl_cache and antigravitycli to use dot-prefixed directory names
</details>

<details>
<summary>docs(opencode): update README directory tree and command references (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/4edefea0">4edefea0</a>)</summary>

- Remove instructions/ and oh-my-opencode.json from directory tree
- Fix command references from /git:commit to /git-commit format
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1945

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
