### PR TITLE
feat(ide): update zed config

### DIFF
--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -211,15 +211,13 @@
       "binary": {
         "path": {{ joinPath (env "XDG_DATA_HOME") "mise" "shims" "tailwindcss-language-server" | quote }},
         "arguments": ["--stdio"]
-      }
-    {{/*
-    },
+      },
     "tombi": {
       "binary": {
         "path": {{ joinPath (env "XDG_DATA_HOME") "mise" "shims" "tombi" | quote }},
         "arguments": ["lsp"]
       }
-    },
+    {{/*
     "biome": {
       "binary": {
         "path": {{ joinPath (env "XDG_DATA_HOME") "mise" "shims" "biome" | quote }},

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -313,12 +313,12 @@
       "formatter": { "external": { "command": "yamlfmt", "arguments": [ "--filename", "{buffer_path}" ] } },
       "language_servers": [ "yaml-language-server" ]
     },
-    {{/*
     "TOML": {
       "format_on_save": "on",
       "formatter": { "language_server": { "name": "tombi" } },
       "language_servers": [ "tombi" ]
     },
+    {{/*
     "KDL": {
       "format_on_save": "on"
     },

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -230,9 +230,21 @@
         "arguments": ["server"]
       }
     },
-    "texlab": {
-      "path": {{ joinPath (env "XDG_DATA_HOME") "mise" "shims" "texlab" | quote }}
     */ -}}
+    },
+    "texlab": {
+      "binary": { "path": {{ joinPath (env "XDG_DATA_HOME") "mise" "shims" "texlab" | quote }} },
+      "settings": {
+        "texlab": {
+          "build": { "onSave": false, "forwardSearchAfter": true },
+          "formatterLineLength": 120,
+          "bibtexFormatter": "texlab",
+          "latexFormatter": "texlab",
+          "diagnostics": {
+            "allowedPatterns": []
+          }
+        }
+      }
     }
   },
   "auto_signature_help": true,


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Add texlab LaTeX LSP configuration with formatter settings
- Uncomment and restore tombi language server config
- Fix TOML formatter comment block placement

### 🎉 New Features

<details>
<summary>feat(zed): add texlab LSP configuration with formatter settings (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/560442ab">560442ab</a>)</summary>

- Expand texlab entry with binary path and diagnostic settings
- Configure build onSave, formatter line length, and allowed patterns
- Enable bibtex and latex formatter for LaTeX support in Zed
</details>

### 🐞 Bug Fixes

<details>
<summary>fix(zed): uncomment tombi language server config (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/60c1266c">60c1266c</a>)</summary>

- Move template comment block to biome section
- Restore tombi LSP configuration in Zed settings
</details>

<details>
<summary>fix(zed): uncomment TOML formatter config (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/9c07d819">9c07d819</a>)</summary>

- Move template comment from TOML to KDL language block
- Restore TOML formatting with tombi language server
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1953

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
