### PR TITLE
feat: Update AI agent notification config

### DIFF
--- a/home/.chezmoidata/ai/herdr.toml
+++ b/home/.chezmoidata/ai/herdr.toml
@@ -1,13 +1,3 @@
 [herdr.ui]
 
-[herdr.sounds.mac]
-path         = "/System/Library/Sounds/Purr.aiff"
-done_path    = "/System/Library/Sounds/Glass.aiff"
-request_path = "/System/Library/Sounds/Submarine.aiff"
-
-[herdr.sounds.linux]
-path         = "/usr/share/sounds/freedesktop/stereo/dialog-information.oga"
-done_path    = "/usr/share/sounds/freedesktop/stereo/complete.oga"
-request_path = "/usr/share/sounds/freedesktop/stereo/message.oga"
-
 [herdr.key]

--- a/home/.chezmoidata/ai/notifications.toml
+++ b/home/.chezmoidata/ai/notifications.toml
@@ -1,0 +1,11 @@
+[ai.notify.sounds.mac]
+command  = "afplay"
+idle     = "/System/Library/Sounds/Purr.aiff"
+complete = "/System/Library/Sounds/Glass.aiff"
+request  = "/System/Library/Sounds/Submarine.aiff"
+
+[ai.notify.sounds.linux]
+command  = "paplay"
+idle     = "/usr/share/sounds/freedesktop/stereo/dialog-information.oga"
+complete = "/usr/share/sounds/freedesktop/stereo/complete.oga"
+request  = "/usr/share/sounds/freedesktop/stereo/message.oga"

--- a/home/dot_config/herdr/config.toml.tmpl
+++ b/home/dot_config/herdr/config.toml.tmpl
@@ -186,9 +186,15 @@ position = "bottom-center"
 [ui.sound]
 enabled = true
 # Optional custom mp3 sound files. Relative paths are resolved from this config file's directory.
-path         = {{- if eq .chezmoi.os "darwin" }}{{ .herdr.sounds.mac.path | quote }}{{- end }} # one mp3 file for all sound notifications
-done_path    = {{- if eq .chezmoi.os "darwin" }}{{ .herdr.sounds.mac.done_path | quote }}{{- end }} # overrides only finished notifications
-request_path = {{- if eq .chezmoi.os "darwin" }}{{ .herdr.sounds.mac.request_path | quote }}{{- end }} # overrides only needs-attention notifications
+{{- if eq .chezmoi.os "darwin" }}
+path         = {{ .ai.notify.sounds.mac.idle | quote }}
+done_path    = {{ .ai.notify.sounds.mac.complete | quote }}
+request_path = {{ .ai.notify.sounds.mac.request | quote }}
+{{- else if eq .chezmoi.os "linux" }}
+path         = {{ .ai.notify.sounds.linux.idle | quote }}
+done_path    = {{ .ai.notify.sounds.linux.complete | quote }}
+request_path = {{ .ai.notify.sounds.linux.request | quote }}
+{{- end }}
 
 # Per-agent overrides: default | on | off
 # By default, droid is muted.

--- a/home/dot_gemini/antigravity-cli/private_hooks.json.tmpl
+++ b/home/dot_gemini/antigravity-cli/private_hooks.json.tmpl
@@ -6,9 +6,9 @@
         "hooks": [
           {
             {{- if eq .chezmoi.os "darwin" }}
-            "command": "afplay /System/Library/Sounds/Submarine.aiff >/dev/null 2>&1 &"
+            "command": "{{ .ai.notify.sounds.mac.command }} {{ .ai.notify.sounds.mac.request }} >/dev/null 2>&1 &",
             {{- else if eq .chezmoi.os "linux" }}
-            "command": "paplay /usr/share/sounds/freedesktop/stereo/message.oga"
+            "command": "{{ .ai.notify.sounds.linux.command }} {{ .ai.notify.sounds.linux.request }} >/dev/null 2>&1 &"
             {{- end }}
           }
         ]
@@ -18,9 +18,9 @@
         "hooks": [
           {
             {{- if eq .chezmoi.os "darwin" }}
-            "command": "afplay /System/Library/Sounds/Purr.aiff >/dev/null 2>&1 &"
+            "command": "{{ .ai.notify.sounds.mac.command }} {{ .ai.notify.sounds.mac.idle }} >/dev/null 2>&1 &",
             {{- else if eq .chezmoi.os "linux" }}
-            "command": "paplay /usr/share/sounds/freedesktop/stereo/dialog-information.oga"
+            "command": "{{ .ai.notify.sounds.linux.command }} {{ .ai.notify.sounds.linux.idle }} >/dev/null 2>&1 &"
             {{- end }}
           }
         ]
@@ -33,9 +33,9 @@
         "hooks": [
           {
             {{- if eq .chezmoi.os "darwin" }}
-            "command": "afplay /System/Library/Sounds/Glass.aiff >/dev/null 2>&1 &"
+            "command": "{{ .ai.notify.sounds.mac.command }} {{ .ai.notify.sounds.mac.complete }} >/dev/null 2>&1 &",
             {{- else if eq .chezmoi.os "linux" }}
-            "command": "paplay /usr/share/sounds/freedesktop/stereo/complete.oga"
+            "command": "{{ .ai.notify.sounds.linux.command }} {{ .ai.notify.sounds.linux.complete }} >/dev/null 2>&1 &"
             {{- end }}
           }
         ]


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Relocate AI sound config to dedicated notifications data layer
- Switch herdr config to centralized ai.notify sound paths
- Update antigravity-cli hooks to use ai.notify sound keys

### Other Changes

<details>
<summary>refactor(ai): relocate sound config to notifications (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/c6086b43">c6086b43</a>)</summary>

- Move sound paths from herdr.toml to dedicated notifications.toml
- Rename table hierarchy from [herdr.sounds] to [ai.notify.sounds]
- Add platform-specific audio command (afplay/paplay)
- Generalize key names for wider reuse (path→idle, done_path→complete, request_path→request)
</details>

<details>
<summary>refactor(herdr): use ai.notify sound data paths (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b3f518f8">b3f518f8</a>)</summary>

- Switch from deprecated .herdr.sounds.mac to .ai.notify.sounds.* data keys
- Add Linux sound path support via .ai.notify.sounds.linux
- Branch template by OS (darwin / linux) for platform-specific paths
</details>

<details>
<summary>refactor(antigravity-cli): use ai.notify sound keys (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b9aa5ca8">b9aa5ca8</a>)</summary>

- Replace hardcoded afplay/paplay commands with .ai.notify.sounds.* keys
- Reference .command and .request / .idle / .complete from data layer
- Add Linux sound command support via template branching
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1963

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
