### PR TITLE
feat: Update oil.nvim snippets

### DIFF
--- a/home/dot_config/nvim/lua/snippets/oil.lua
+++ b/home/dot_config/nvim/lua/snippets/oil.lua
@@ -31,7 +31,6 @@ local snippets = {
     .lefthook.yml
     .rumdl.toml
     .typos.toml
-    .editorconfig
     .github/CODEOWNERS
     .github/CONTRIBUTING.md
     .github/SECURITY.md

--- a/home/dot_config/nvim/lua/snippets/oil.lua
+++ b/home/dot_config/nvim/lua/snippets/oil.lua
@@ -62,15 +62,5 @@ local snippets = {
     .opencode/AGENTS.md
     ]], {})
   ),
-  s({ trig = ";omp", name = "oh-my-pi", dscr = "omp Template" },
-    fmt([[
-    .omp/agent/
-    .omp/commands/
-    .omp/rules/
-    .omp/skills/
-    .omp/SYSTEM.md
-    .omp/RULES.md
-    ]], {})
-  ),
 }
 return snippets


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Remove duplicate .editorconfig entry from oil.nvim snippets
- Remove oh-my-pi file template snippet from oil.nvim

### 🐞 Bug Fixes

<details>
<summary>fix(nvim): remove duplicate editorconfig from oil file template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/ff9ab83d514f053b9ebafc87da9fb466bfa92b19">ff9ab83</a>)</summary>

- Remove .editorconfig entry from oil.nvim snippets
- Already defined via root dot_editorconfig.tmpl chezmoi template
</details>

### Other Changes

<details>
<summary>chore(nvim): remove oh-my-pi template from oil snippets (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/fbc5efb417185197eafb2d13628bfe2260fa6cd8">fbc5efb</a>)</summary>

- Remove oh-my-pi file template snippet from oil.lua
- Clean up snippet following removal of oh-my-pi from mise tools
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1977

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
