### PR TITLE
feat(nvim): Add typescript snippets

### DIFF
--- a/home/dot_config/nvim/lua/snippets/typescript.lua
+++ b/home/dot_config/nvim/lua/snippets/typescript.lua
@@ -1,0 +1,73 @@
+---@diagnostic disable: unused-local
+local ls = require("luasnip")
+local s  = ls.snippet
+local t  = ls.text_node
+local i  = ls.insert_node
+local c  = ls.choice_node
+local d  = ls.dynamic_node
+local r  = ls.restore_node
+-- local f  = ls.function_node
+local sn = ls.snippet_node
+local isn = ls.indent_snippet_node
+-- local as = ls.extend_decorator.apply(s, { snippetType = "autosnippet" })
+local extras = require("luasnip.extras")
+local rep    = extras.rep
+-- local m      = extras.m
+-- local l      = extras.l
+-- local fmt     = require("luasnip.extras.fmt").fmt
+local fmta    = require("luasnip.extras.fmt").fmta
+-- local postfix = require("luasnip.extras.postfix").postfix
+-- local conds   = require("luasnip.extras.conditions")
+-- local condse  = require("luasnip.extras.conditions.expand")
+
+local function functionator(type)
+  return fmta('<doc>\n<type> <async><name>(<params>): <ret>{\n\t<body>\n}', {
+    doc    = isn(1, {
+      t({ "/**", " " }),
+      i(1, "function description"),
+      c(2, { sn(nil, { t({ "", " @returns " }), i(1, "return description") }) }),
+      t({ "", "/" }),
+    }, "$PARENT_INDENT *"),
+    type   = t(type),
+    async  = c(2, { t("async "), t("") }),
+    name   = i(3, "function name"),
+    params = i(4),
+    ret    = d(5, function(args)
+      local async = string.match(args[1][1], "async")
+        if async == nil then
+          return sn(nil, { r(1, "return_type", i(nil, "void")) } )
+        end
+        return sn(nil, { t("Promise<"), r(1, "return_type", i(nil, "void")), t(">") } )
+    end),
+    body = i(0),
+  })
+end
+
+local function looper(type)
+  return fmta('.<type>{<async>}<<item>> => {\n\t<body>\n}', {
+    type  = t(type),
+    async = c(1, { t(""), t("async ") }),
+    item  = c(2, { i(1, "item"), sn(nil, { t("{ "), i(1, "field"), t(" }") }) }),
+    body  = i(0),
+  })
+end
+
+local snippets = {
+  -- Function snippets
+  s({ trig = "pbf", name = "public function",  dscr = "public function" },  functionator("public") ),
+  s({ trig = "prf", name = "private function", dscr = "private function" }, functionator("private") ),
+
+  -- Array snippets
+  s({ trig = ".map",     name = "map",     dscr = "" }, looper("map") ),
+  s({ trig = ".filter",  name = "filter",  dscr = "" }, looper("filter") ),
+  s({ trig = ".forEach", name = "forEach", dscr = "" }, looper("forEach") ),
+  s({ trig = ".find",    name = "find",    dscr = "" }, looper("find") ),
+  s({ trig = ".some",    name = "some",    dscr = "" }, looper("some") ),
+  s({ trig = ".every",   name = "every",   dscr = "" }, looper("every") ),
+
+  s({ trig = "cl", name = "console.log", dscr = "console.log" }, fmta('console.log(<>);', { i(0) }) ),
+  s({ trig = "clv", name = "console.log w/ variables", dscr = "console.log with variables" },
+    fmta('console.log("<>", <>);', { i(1), rep(1) })
+  ),
+}
+return snippets

--- a/home/dot_config/nvim/lua/snippets/typescriptreact.lua
+++ b/home/dot_config/nvim/lua/snippets/typescriptreact.lua
@@ -6,14 +6,14 @@ local i  = ls.insert_node
 -- local c  = ls.choice_node
 -- local d  = ls.dynamic_node
 -- local r  = ls.restore_node
-local f  = ls.function_node
+-- local f  = ls.function_node
 -- local sn = ls.snippet_node
 -- local as = ls.extend_decorator.apply(s, { snippetType = "autosnippet" })
 -- local extras = require("luasnip.extras")
 -- local rep    = extras.rep
 -- local m      = extras.m
 -- local l      = extras.l
-local fmt     = require("luasnip.extras.fmt").fmt
+-- local fmt     = require("luasnip.extras.fmt").fmt
 local fmta    = require("luasnip.extras.fmt").fmta
 -- local postfix = require("luasnip.extras.postfix").postfix
 -- local conds   = require("luasnip.extras.conditions")

--- a/home/dot_config/nvim/lua/snippets/typescriptreact.lua
+++ b/home/dot_config/nvim/lua/snippets/typescriptreact.lua
@@ -1,0 +1,41 @@
+---@diagnostic disable: unused-local
+local ls = require("luasnip")
+local s  = ls.snippet
+-- local t  = ls.text_node
+local i  = ls.insert_node
+-- local c  = ls.choice_node
+-- local d  = ls.dynamic_node
+-- local r  = ls.restore_node
+local f  = ls.function_node
+-- local sn = ls.snippet_node
+-- local as = ls.extend_decorator.apply(s, { snippetType = "autosnippet" })
+-- local extras = require("luasnip.extras")
+-- local rep    = extras.rep
+-- local m      = extras.m
+-- local l      = extras.l
+local fmt     = require("luasnip.extras.fmt").fmt
+local fmta    = require("luasnip.extras.fmt").fmta
+-- local postfix = require("luasnip.extras.postfix").postfix
+-- local conds   = require("luasnip.extras.conditions")
+-- local condse  = require("luasnip.extras.conditions.expand")
+
+local snippets = {
+  -- React directives
+  s({ trig = ";uc", name = "use client", dscr = "use client directive" }, fmta('"use client"', {}) ),
+  s({ trig = ";us", name = "use server", dscr = "use server directive" }, fmta('"use server"', {}) ),
+
+  -- INFO: React hooks leave it to friendly snippets
+
+  -- Class name
+  s({ trig = "cn", name = "cn() className helper" }, fmta('cn(<>)', { i(0, "Class name") }) ),
+  s({ trig = "cva", name = "cva() variant definition" },
+    fmta([[
+      const <> = cva("<>", {
+        variants: {
+          <>
+        }
+      })
+    ]], { i(1, "variants"), i(2, "base-classes"), i(3, "") })
+  ),
+}
+return snippets


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Add TypeScript and TypeScript React LuaSnip snippets for Neovim
- Clean up unused imports in existing snippet files

### 🎉 New Features

<details>
<summary>feat(nvim): add TypeScript snippets (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/85684b7085263b93be6b67df71c310c6615a5c31">85684b7</a>)</summary>

- Add functionator() helper for typed function snippets with JSDoc
- Add looper() helper for array iteration method snippets
- Add console.log snippets with variable logging support
</details>

<details>
<summary>feat(nvim): add TypeScript React snippets (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/92dfaa6b10f97caf20ec728425578d39f1d3c37c">92dfaa6</a>)</summary>

- Add "use client" and "use server" directive snippets
- Add cn() className helper snippet
- Add cva() variant definition snippet with template
</details>

### Other Changes

<details>
<summary>style(nvim): comment out unused luasnip imports (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/739169b9cf21c792281646fd06364ce130b550ae">739169b</a>)</summary>

- Comment out unused function_node and fmt imports
- Clean up dead code in TypeScript React snippets file
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1979

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
