### PR TITLE
feat(mise): remove unused tools

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -185,8 +185,6 @@ ruby    = "3"
 "aqua:FiloSottile/age"           = "latest" # Simple encrypt / decrypt tool
 "github:betterleaks/betterleaks" = "latest" # A Better Secrets Scanner built for configurability and speed
 "github:jdx/fnox"                = "latest" # encrypted/remote secret manager
-"github:AikidoSec/safe-chain"    = "latest" # Protect against malicious code installed via npm, yarn, pnpm, npx, pnpx, pip, uv and poetry
-"github:OWASP/cve-lite-cli"      = "latest" # Vulnerability scanning that belongs in your terminal
 
 ## Utility
 "github:ksdme/ut" = "latest" # A Rust based utility toolbox for developers

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -199,9 +199,6 @@ ruby    = "3"
 "github:azu/dockerfile-pin" = "latest" # Docker image digest pinner
 "npm:@devcontainers/cli"    = "latest" # Dev Container CLI
 
-## Web
-"npm:clerk" = "latest"
-
 ## AI Tools
 ### AI Agents
 "github:microsoft/apm"                    = { version = "latest", minimum_release_age = "1d" }


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Remove unused security audit tools from mise config
- Remove unused Clerk package from mise config

### Other Changes

<details>
<summary>chore(mise): remove unused security audit tools (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/3c13a9e1">3c13a9e1</a>)</summary>

- Remove safe-chain (malicious code protection for npm/pip)
- Remove cve-lite-cli (vulnerability scanning CLI)
- These should be installed per-project in js/ts or python based repos
</details>

<details>
<summary>chore(mise): remove unused Clerk package (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7d0f3409">7d0f3409</a>)</summary>

- Remove unused Clerk npm package entry
- Remove associated ## Web section header
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1982

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
