### PR TITLE
feat(ide): Update Zed AI config

### DIFF
--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -388,10 +388,15 @@
     "auto_compact": { "enabled": true, "threshold": "80%" },
     "play_sound_when_agent_done": "always",
     "default_model": {
-      "enable_thinking": true,
       "provider": "opencode",
-      "model": "zen/deepseek-v4-flash-free"
+      "model": "zen/deepseek-v4-flash-free",
+      "enable_thinking": true
     },
+    {{/*
+    "inline_assistant_model": { "provider": "opencode", "model": "zen/deepseek-v4-flash-free", "enable_thinking": false },
+    "subagent_model": { "provider": "opencode", "model": "zen/deepseek-v4-flash-free", "enable_thinking": true },
+    */ -}}
+    "thread_summary_model": { "provider": "opencode", "model": "zen/deepseek-v4-flash-free", "enable_thinking": true },
     "model_parameters": [],
     "enable_feedback": false
   },

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -399,6 +399,13 @@
     "gemini": {"type": "registry", "env": {"GEMINI_SANDBOX": "true"} },
     "opencode": {"type": "registry" }
   },
+  "language_models": {
+    "opencode": {
+      "show_zen_models": true,
+      "show_go_models": false,
+      "show_free_models": true
+    }
+  },
   "edit_predictions": {
     "disabled_globs": [ "**/.env*", "**/*.age", "**/secrets/**", "**/*.pem", "**/*.key", "**/*.cert" ]
   }

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -176,7 +176,7 @@
           "functionReturnTypes": true,
           "parameterTypes": true,
           "parameterNames": true
-        },
+        }
       }
     },
     "ruff": {
@@ -225,7 +225,7 @@
           "format": { "enable": false, "singleQuote": false },
           "validate": { "enable": true },
           "completion": true,
-          "hover": true,
+          "hover": true
         }
       }
     },
@@ -387,8 +387,8 @@
     "dock": "right",
     "default_model": {
       "enable_thinking": true,
-      "provider": "ollama",
-      "model": "qwen3.5:cloud"
+      "provider": "opencode",
+      "model": "zen/deepseek-v4-flash-free"
     },
     "model_parameters": [],
     "enable_feedback": false

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -385,6 +385,8 @@
   */ -}}
   "agent": {
     "dock": "right",
+    "auto_compact": { "enabled": true, "threshold": "80%" },
+    "play_sound_when_agent_done": "always",
     "default_model": {
       "enable_thinking": true,
       "provider": "opencode",

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -412,7 +412,9 @@
     }
   },
   "edit_predictions": {
-    "disabled_globs": [ "**/.env*", "**/*.age", "**/secrets/**", "**/*.pem", "**/*.key", "**/*.cert" ]
+    "provider": "zed",
+    "mode": "eager",
+    "disabled_globs": [ "**/.env*", "**/*.age", "**/secrets/**", "**/*.pem", "**/*.key", "**/*.cert", "**/secrets.yml" ]
   }
 }
 {{- /*


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Set deepseek-v4-flash-free as the default AI model in Zed
- Enable agent auto-compact and completion sound
- Show opencode zen/free models in the model picker
- Switch thread summary model to opencode
- Enable Zed edit predictions with eager mode

### 🎉 New Features

<details>
<summary>feat(zed): set deepseek-v4-flash-free as default (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/26c1a2a6ec223bb15f5fba51506000a492e6a222">26c1a2a</a>)</summary>

- Change AI model provider from ollama/qwen3.5:cloud to opencode/zen/deepseek-v4-flash-free
- Fix trailing commas in settings template to produce valid JSON
</details>

<details>
<summary>feat(zed): add agent auto-compact and done sound (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/cd7302021cdeee1909d1b9b630a62ace65d52e60">cd73020</a>)</summary>

- Enable auto_compact with 80% context threshold to manage agent memory
- Play a sound notification when the agent finishes
</details>

<details>
<summary>feat(zed): add opencode language model visibility (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/72c8314a3b144c2c0fa4128faccf159c4130d2c6">72c8314</a>)</summary>

- Show zen and free models from opencode provider in Zed agent
- Hide go models from model picker
- Add language_models config block to agent settings template
</details>

<details>
<summary>feat(zed): switch thread summary model to opencode (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/1463d5c50434dab8789b70aefadb337150509f50">1463d5c</a>)</summary>

- Change thread_summary_model from copilot to opencode with zen/deepseek-v4-flash-free
- Comment out inline_assistant_model and subagent_model settings via template comments
- Reorder enable_thinking in default_model for JSON consistency
</details>

<details>
<summary>feat(zed): enable zed edit predictions (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/081036a0826a86bbc8f1852b672796bdd093347f">081036a</a>)</summary>

- Set edit_predictions provider to zed with eager mode
- Add secrets.yml to disabled_globs to exclude from prediction
- Keep existing secret file patterns excluded from edit predictions
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1989

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
