### PR TITLE
feat(ide): Update Zed LSP config

### DIFF
--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -309,7 +309,8 @@
   "languages": {
     "Shell Script": {
       "format_on_save": "on",
-      "formatter": { "external": { "command": "shfmt", "arguments": [ "--filename", "{buffer_path}" ] } }
+      "formatter": { "external": { "command": "shfmt", "arguments": [ "--filename", "{buffer_path}" ] } },
+      "language_servers": ["bash-language-server"]
     },
     "C": {
       "format_on_save": "on",

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -259,6 +259,14 @@
         "config_path": "./biome.json"
       }
     },
+    "oxfmt": {
+      "initialization_options": {
+        "settings": {
+          "fmt.configPath": "oxfmt.config.ts",
+          "run": "onSave"
+        }
+      }
+    },
     "texlab": {
       "settings": {
         "texlab": {

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -279,6 +279,9 @@
         }
       }
     },
+    "rumdl": {
+      "binary": { "path": "rumdl", "arguments": ["server"] }
+    },
     "texlab": {
       "settings": {
         "texlab": {
@@ -406,7 +409,10 @@
       "language_servers": ["!biome", "!prettier", "!eslint", "..."]
     },
     "Markdown": {
-      "language_servers": [ "!biome", "!prettier", "!eslint", "marksman" ]
+      "format_on_save": "on",
+      "prettier": { "allowed": false },
+      "formatter": { "language_server": { "name": "rumdl" } },
+      "language_servers": [ "rumdl", "!biome", "!prettier", "!eslint" ]
     },
     "Markdown-Inline": {
       "show_edit_predictions": false

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -267,6 +267,18 @@
         }
       }
     },
+    "oxlint": {
+      "initialization_options": {
+        "settings": {
+          "configPath": "oxlint.config.ts",
+          "run": "onType",
+          "disableNestedConfig": false,
+          "fixKind": "safe_fix",
+          "typeAware": true,
+          "unusedDisableDirectives": "deny"
+        }
+      }
+    },
     "texlab": {
       "settings": {
         "texlab": {

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -255,7 +255,8 @@
     },
     "biome": {
       "settings": {
-        "require_config_file": true
+        "require_config_file": true,
+        "config_path": "./biome.json"
       }
     },
     "texlab": {

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -348,20 +348,20 @@
     },
     "JavaScript": {
       "format_on_save": "on",
-      "formatter": { "language_server": { "name": "biome" } }
+      "formatter": { "language_server": { "name": "oxfmt" } }
     },
     "TypeScript": {
       "format_on_save": "on",
-      "formatter": { "language_server": { "name": "biome" } }
+      "formatter": { "language_server": { "name": "oxfmt" } }
     },
     "TSX": {
       "format_on_save": "on",
-      "formatter": { "language_server": { "name": "biome" } },
+      "formatter": { "language_server": { "name": "oxfmt" } },
       "language_servers": [ "biome", "!eslint", "!stylelint-lsp" ]
     },
     "JSON": {
       "format_on_save": "on",
-      "formatter": { "language_server": { "name": "biome" } },
+      "formatter": { "language_server": { "name": "oxfmt" } },
       "language_servers": [ "json-language-server" ]
     },
     "YAML": {
@@ -380,11 +380,12 @@
     },
     */ -}}
     "HTML": {
-      "format_on_save": "on"
+      "format_on_save": "on",
+      "formatter": { "language_server": { "name": "oxfmt" } }
     },
     "CSS": {
       "format_on_save": "on",
-      "formatter": { "language_server": { "name": "biome" } }
+      "formatter": { "language_server": { "name": "oxfmt" } }
     },
     "Markdown": {
       "language_servers": [ "marksman" ]

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -166,6 +166,11 @@
         "staticcheck": true
       }
     },
+    "golangci-lint": {
+      "initialization_options": {
+        "command": ["golangci-lint", "run", "--output.json.path=stdout", "--issues-exit-code=1", "--show-stats=false"]
+      }
+    },
     "ty": {
       "settings": {
         "completions": { "autoImport": true },
@@ -333,7 +338,7 @@
     "Go": {
       "format_on_save": "on",
       "formatter": { "external": { "command": "golangci-lint", "arguments": [ "fmt", "--stdin" ] } },
-      "language_servers": [ "gopls" ]
+      "language_servers": [ "gopls", "golangci-lint" ]
     },
     "Python": {
       "format_on_save": "on",

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -349,31 +349,45 @@
     },
     "JavaScript": {
       "format_on_save": "on",
-      "formatter": { "language_server": { "name": "oxfmt" } }
+      "prettier": { "allowed": false },
+      "formatter": { "language_server": { "name": "oxfmt" } },
+      "language_servers": ["typescript-language-server", "oxlint", "oxfmt", "!!biome", "!prettier", "!eslint", "..."]
     },
     "TypeScript": {
       "format_on_save": "on",
-      "formatter": { "language_server": { "name": "oxfmt" } }
+      "prettier": { "allowed": false },
+      "formatter": { "language_server": { "name": "oxfmt" } },
+      "language_servers": ["typescript-language-server", "oxlint", "oxfmt", "!tsgo", "!vtsls", "!!biome", "!prettier", "!eslint", "..."]
     },
     "TSX": {
       "format_on_save": "on",
+      "prettier": { "allowed": false },
       "formatter": { "language_server": { "name": "oxfmt" } },
-      "language_servers": [ "biome", "!eslint", "!stylelint-lsp" ]
+      "language_servers": ["typescript-language-server", "oxlint", "oxfmt", "!tsgo", "!vtsls", "!!biome", "!prettier", "!eslint", "..."]
     },
     "JSON": {
       "format_on_save": "on",
+      "prettier": { "allowed": false },
       "formatter": { "language_server": { "name": "oxfmt" } },
-      "language_servers": [ "json-language-server" ]
+      "language_servers": ["!!biome", "!prettier", "!eslint", "..."]
+    },
+    "JSONC": {
+      "format_on_save": "on",
+      "prettier": { "allowed": false },
+      "formatter": { "language_server": { "name": "oxfmt" } },
+      "language_servers": ["!!biome", "!prettier", "!eslint", "..."]
     },
     "YAML": {
       "format_on_save": "on",
+      "prettier": { "allowed": false },
       "formatter": { "external": { "command": "yamlfmt", "arguments": [ "--filename", "{buffer_path}" ] } },
-      "language_servers": [ "yaml-language-server" ]
+      "language_servers": ["!!biome", "!prettier", "!eslint", "..."]
     },
     "TOML": {
       "format_on_save": "on",
+      "prettier": { "allowed": false },
       "formatter": { "language_server": { "name": "tombi" } },
-      "language_servers": [ "tombi" ]
+      "language_servers": [ "!biome", "!prettier", "!eslint", "tombi", "..." ]
     },
     {{/*
     "KDL": {
@@ -382,14 +396,17 @@
     */ -}}
     "HTML": {
       "format_on_save": "on",
+      "prettier": { "allowed": false },
       "formatter": { "language_server": { "name": "oxfmt" } }
     },
     "CSS": {
       "format_on_save": "on",
-      "formatter": { "language_server": { "name": "oxfmt" } }
+      "prettier": { "allowed": false },
+      "formatter": { "language_server": { "name": "oxfmt" } },
+      "language_servers": ["!biome", "!prettier", "!eslint", "..."]
     },
     "Markdown": {
-      "language_servers": [ "marksman" ]
+      "language_servers": [ "!biome", "!prettier", "!eslint", "marksman" ]
     },
     "Markdown-Inline": {
       "show_edit_predictions": false


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Update Zed LSP configuration for oxlint, oxfmt, biome, and rumdl
- Activate bash-language-server for shell scripts
- Switch formatter from biome to oxfmt
- Add golangci-lint as Go LSP server
- Refine language server selection across TS, JSON, YAML, TOML, and CSS
- Set biome config path in LSP settings

### 🎉 New Features

<details>
<summary>feat(zed): add golangci-lint LSP server for Go (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/fd8e608cbf7d2a5e6b55bfd5cbaded3f1a965c41">fd8e608</a>)</summary>

• Configure golangci-lint with JSON output and exit-code flags
• Enable golangci-lint alongside gopls for Go language
</details>

<details>
<summary>feat(zed): use rumdl for markdown LSP formatting (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/696f2cc9caae68f4a77fe68b88d6fde6e1ff8f7a">696f2cc</a>)</summary>

• Add rumdl LSP server binary block for markdownlint server
• Set rumdl as formatter for Markdown language
• Replace marksman with rumdl in language_servers for Markdown
</details>

<details>
<summary>feat(zed): refine LSP server selection (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/683752ebae3246075c819314945fded4c124d872">683752e</a>)</summary>

• Disable prettier and biome globally via language_servers directives
• Expand language_servers with "..." wildcard to include default servers
• Add JSONC language block with oxfmt formatter
• Explicitly disable tsgo, vtsls, and eslint across TS languages
</details>

<details>
<summary>feat(zed): activate bash language server for shell scripts (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/f1c27066d1c0bb2a31517a9a8dfcdc6e3f72e94e">f1c2706</a>)</summary>

• Enable bash-language-server for the Shell Script language
• Keep shfmt as external formatter
</details>

<details>
<summary>feat(zed): switch formatter from biome to oxfmt (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/7e54caa28bd26af4a46dcd201bf484bda4bdc6e7">7e54caa</a>)</summary>

• Use oxfmt as language server formatter for JavaScript, TypeScript, TSX, JSON, CSS
• Add oxfmt formatter to language block previously missing one
</details>

<details>
<summary>feat(zed): add oxlint LSP config (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/ab49ee3a54d782f5137c5b3d254fd580bec58f52">ab49ee3</a>)</summary>

• Add oxlint LSP block with configPath oxlint.config.ts
• Enable onType run with safe_fix and type-aware analysis
• Deny unused disable directives
</details>

<details>
<summary>feat(zed): add oxfmt LSP on-save formatting (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/b877422a89a64c88844ae109b4cfe3844f9411b7">b877422</a>)</summary>

• Add oxfmt LSP block with fmt.configPath oxfmt.config.ts
• Run oxfmt formatting on save
</details>

<details>
<summary>feat(zed): set biome config path in LSP settings (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/a22b943ba450b03ee413db73b1a96e6da46fd2e7">a22b943</a>)</summary>

• Add config_path ./biome.json to biome LSP settings
• Keep require_config_file true to enforce config presence
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1993

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
