### PR TITLE
feat(ide): Update Zed tasks

### DIFF
--- a/home/.chezmoitemplates/common/zed/tasks.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/tasks.json.tmpl
@@ -12,6 +12,10 @@
     "show_command": false
   },
   {
+    "label": "Open in Ghostty",
+    "command": "ghostty --working-directory=$ZED_WORKTREE_ROOT"
+  },
+  {
     "label": "chezmoi apply",
     "command": "chezmoi",
     "args": ["apply", "--verbose"],

--- a/home/.chezmoitemplates/common/zed/tasks.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/tasks.json.tmpl
@@ -1,5 +1,17 @@
 [
   {
+    "label": "Onefetch",
+    "command": "onefetch",
+    "user_new_terminal": true,
+    "allow_concurrent_runs": true,
+    "reveal": "always",
+    "reveal_target": "center",
+    "hide": "never",
+    "shell": "system",
+    "show_summary": false,
+    "show_command": false
+  },
+  {
     "label": "chezmoi apply",
     "command": "chezmoi",
     "args": ["apply", "--verbose"],

--- a/home/.chezmoitemplates/common/zed/tasks.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/tasks.json.tmpl
@@ -1,17 +1,5 @@
 [
   {
-    "label": "gitui",
-    "command": "gitui",
-    "shell": { "program": "sh" },
-    "cwd": "$ZED_WORKTREE_ROOT",
-    "hide": "on_success",
-    "reveal_target": "center",
-    "show_summary": false,
-    "show_command": false,
-    "allow_concurrent_runs": false,
-    "use_new_terminal": true,
-  },
-  {
     "label": "chezmoi apply",
     "command": "chezmoi",
     "args": ["apply", "--verbose"],


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Add "Open in Ghostty" task to Zed tasks template
- Add Onefetch task to Zed tasks template
- Remove duplicate gitui task from Zed tasks template

### 🎉 New Features

<details>
<summary>feat(zed): add open in ghostty task (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/cdf0027d">cdf0027d</a>)</summary>

- Add "Open in Ghostty" task to the Zed tasks configuration template
- Launch ghostty with current workspace as working directory
- Pass $ZED_WORKTREE_ROOT to open the active project root
</details>

<details>
<summary>feat(zed): add onefetch task template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/056a7e1d">056a7e1d</a>)</summary>

- Add Onefetch task to the Zed tasks configuration template
- Run onefetch in a new terminal with concurrent runs allowed
- Configure reveal to "always" centered with no summary or command shown
</details>

### Other Changes

<details>
<summary>refactor(zed): remove gitui task from tasks template (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/2a1b9f03">2a1b9f03</a>)</summary>

- Remove the "gitui" task definition from common Zed tasks.json.tmpl
- Drop duplicate gitui entry that cluttered the Zed task menu
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #2000

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
