### PR TITLE
feat(terminal): Update ghostty config

### DIFF
--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -56,7 +56,7 @@ gtk-wide-tabs       = false
 ## Quick Terminal
 quick-terminal-position = bottom
 quick-terminal-screen   = main
-quick-terminal-size     = 65%, 90%
+quick-terminal-size     = 75%, 90%
 quick-terminal-animation-duration = 0.1
 
 ## Window

--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -180,6 +180,7 @@ keybind = super+9=last_tab
 
 {{- if .ghostty.modes.vim.enabled }}
 #### Vim mode
+keybind = vim/
 
 ##### Enter / Exit vim mode
 keybind = alt+v=activate_key_table:vim

--- a/home/.chezmoitemplates/common/ghostty/config.tmpl
+++ b/home/.chezmoitemplates/common/ghostty/config.tmpl
@@ -132,7 +132,7 @@ keybind = super+k=clear_screen
 keybind = super+ctrl+f=toggle_fullscreen
 keybind = super+c=copy_to_clipboard
 keybind = super+v=paste_from_clipboard
-keybind = super+shift+enter=toggle_split_zoom
+keybind = super+period=toggle_split_zoom
 keybind = global:super+ctrl+enter=toggle_quick_terminal
 
 {{- if eq .chezmoi.os "darwin" }}

--- a/home/dot_config/ghostty/README.md
+++ b/home/dot_config/ghostty/README.md
@@ -68,6 +68,7 @@ The configuration is generated from a centralized template:
 | `Super + Shift + h/j/k/l` | Navigate Splits (Directional) |
 | `Ctrl + Left/Right`       | Resize Split (Horizontal)     |
 | `Ctrl + 0`                | Equalize Splits               |
+| `Super + .`               | toggle zooming of the split   |
 
 ### Tabs
 
@@ -93,6 +94,16 @@ Custom mappings for better shell interaction:
 - `Super + Right`: End of line/buffer
 - `Super + Backspace`: Delete line
 - `Option + Backspace`: Delete word
+
+### Vim mode
+
+Key table for Vim
+
+| Key                  | Action                     |
+|:---------------------|:---------------------------|
+| `alt + v`            | Activate Vim mode          |
+| `escape or i or q`   | Deactivate Vim mode        |
+| `Shift + ;`          | Toggle command palette     |
 
 ## 🔧 Template Variables
 


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Widen Ghostty quick terminal size to 75%
- Rebind split zoom toggle to `Super + .`
- Register vim key table for vim-mode navigation
- Document split zoom and vim mode keybindings

### Other Changes

<details>
<summary>docs(ghostty): document split zoom and vim mode keys (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/8af78c81">8af78c81</a>)</summary>

- Add Super + . row for split zoom toggle in keybindings table
- Add Vim mode section covering activation and deactivation keys
- Document command palette toggle with Shift + ;
</details>

<details>
<summary>chore(ghostty): add vim key table declaration (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/2a6a50bb">2a6a50bb</a>)</summary>

- Add keybind = vim/ to register the vim key table
- Enable existing vim-mode navigation bindings to take effect
</details>

<details>
<summary>chore(ghostty): rebind split zoom toggle to super+period (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/5d8ef31f">5d8ef31f</a>)</summary>

- Change toggle_split_zoom keybind from super+shift+enter to super+period
- Avoid conflict with existing split keybinds
</details>

<details>
<summary>chore(ghostty): widen quick terminal size (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/f591ab55">f591ab55</a>)</summary>

- Increase quick-terminal-size width from 65% to 75%
- Keep height at 90% for the quick terminal overlay
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #2007

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
