### PR TITLE
feat: Update tv config

### DIFF
--- a/home/dot_config/television/cable/gh-repos.toml.tmpl
+++ b/home/dot_config/television/cable/gh-repos.toml.tmpl
@@ -71,7 +71,7 @@ mode        = "fork"
 
 [actions.yank]
 description = "Copy repo URL to clipboard"
-command     = "echo {strip_ansi|split: :0} | {{ .cmd.copy }}"
+command     = "echo 'https://github.com/{strip_ansi|split: :0}' | {{ .cmd.copy }}"
 mode        = "fork"
 
 [actions.clone]

--- a/home/dot_config/television/cable/git-repos.toml.tmpl
+++ b/home/dot_config/television/cable/git-repos.toml.tmpl
@@ -1,6 +1,6 @@
 [metadata]
 name         = "git-repos"
-requirements = ["fd", "git", "glow"]
+requirements = ["fd", "git"]
 description  = """
 A channel to select from git repositories on your local machine.
 

--- a/home/dot_config/television/cable/git-stash.toml
+++ b/home/dot_config/television/cable/git-stash.toml
@@ -22,7 +22,7 @@ layout = "landscape"
 
   [ui.preview_panel]
   header = "{0}"
-  footer = "enter: apply | ⌃ + p: pop | ⌃ + d: drop"
+  footer = "⏎: apply | ⌃ + p: pop | ⌃ + d: drop"
 
 [keybindings]
 enter  = "actions:apply"

--- a/home/dot_config/television/cable/ssh-hosts.toml
+++ b/home/dot_config/television/cable/ssh-hosts.toml
@@ -1,0 +1,18 @@
+[metadata]
+name         = "ssh-hosts"
+description  = "A channel to select hosts from your SSH config"
+requirements = ["grep", "tr", "cut", "awk"]
+
+[source]
+command = "grep -E '^Host(name)? ' $HOME/.ssh/config | tr -s ' ' | cut -d' ' -f2- | tr ' ' '\n' | grep -v '^$'"
+
+[preview]
+command = "awk '/^Host / { found=0 } /^Host (.*[[:space:]])?'{}'([[:space:]].*)?$/ { found=1 } found' $HOME/.ssh/config"
+
+[keybindings]
+enter = "actions:connect"
+
+[actions.connect]
+description = "SSH into the selected host"
+command     = "ssh {}"
+mode        = "execute"

--- a/home/dot_config/television/cable/zellij-sessions.toml
+++ b/home/dot_config/television/cable/zellij-sessions.toml
@@ -1,0 +1,28 @@
+[metadata]
+name         = "zellij-sessions"
+description  = "List and manage Zellij sessions"
+requirements = ["zellij"]
+
+[source]
+command = "zellij list-sessions --no-formatting --short"
+
+[ui]
+layout = "landscape"
+
+  [ui.input_bar]
+  position = "top"
+  prompt   = "  "
+
+[keybindings]
+ctrl-o = "actions:attach"
+ctrl-q = "actions:detach"
+
+[actions.attach]
+description = "Attach selected zellij session"
+command     = "zellij attach {}"
+mode        = "execute"
+
+[actions.detach]
+description = "Detach selected zellij session"
+command     = "zellij delete-session {}"
+mode        = "execute"

--- a/home/dot_config/television/config.toml.tmpl
+++ b/home/dot_config/television/config.toml.tmpl
@@ -53,7 +53,7 @@ orientation = "landscape"
 # A list of builtin themes can be found in the `themes` directory of the television
 # repository. You may also create your own theme by creating a new file in a `themes`
 # directory in your configuration directory (see the `config.toml` location above).
-theme = "default"
+theme = "catppuccin"
 
 # Feature-specific configurations
 # Each feature can have its own configuration section


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog                                                                                                      
                                                                                                                   
#### What's Changed                                                                                                
                                                                                                                   
- Add zellij sessions and ssh hosts cable channels for television                                                  
- Fix gh-repos channel to copy full GitHub URLs instead of bare slugs                                              
- Remove unused glow dependency from git-repos channel requirements                                                
- Standardize keybinding hint symbols in git-stash channel footer                                                  
- Switch default television theme to catppuccin                                                                    
                                                                                                                   
#### 🎉 New Features                                                                                               
                                                                                                                   
<details>                                                                                                          
<summary>feat(tv): add zellij sessions cable channel (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/  
89b44dcd">89b44dcd</a>)</summary>                                                                                  
                                                                                                                   
- List Zellij sessions via `zellij list-sessions --short` in landscape layout                                      
- Bind ctrl-o to attach and ctrl-q to delete the selected session                                                  
- Declare `zellij` as requirement in channel metadata                                                              
</details>                                                                                                         
                                                                                                                   
<details>                                                                                                          
<summary>feat(tv): add ssh hosts cable channel (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/        
003c7149">003c7149</a>)</summary>                                                                                  
                                                                                                                   
- Parse host entries from ~/.ssh/config via grep/awk pipeline                                                      
- Preview full host config block for the selected entry                                                            
- Bind enter to connect with `ssh {}`                                                                              
</details>                                                                                                         
                                                                                                                   
#### 🐞 Bug Fixes                                                                                                  
                                                                                                                   
<details>                                                                                                          
<summary>fix(tv): copy full repo url in gh-repos channel (<a href="https://github.com/MasahiroSakoda/dotfiles/     
commit/c52e773e">c52e773e</a>)</summary>                                                                           
                                                                                                                   
- Prefix copied value with https://github.com/ so clipboard gets a usable link                                     
- Previously only the owner/repo slug was copied, requiring manual URL assembly                                    
</details>                                                                                                         
                                                                                                                   
#### Other Changes                                                                                                 
                                                                                                                   
<details>                                                                                                          
<summary>chore(tv): drop glow from git-repos requirements (<a href="https://github.com/MasahiroSakoda/dotfiles/    
commit/2cff47d2">2cff47d2</a>)</summary>                                                                           
                                                                                                                   
- Remove unused `glow` from the channel's requirements list                                                        
- Keep `fd` and `git` as the only required dependencies                                                            
</details>                                                                                                         
                                                                                                                   
<details>                                                                                                          
<summary>style(tv): use return symbol in git-stash footer (<a href="https://github.com/MasahiroSakoda/dotfiles/    
commit/f062e9ef">f062e9ef</a>)</summary>                                                                           
                                                                                                                   
- Replace "enter" label with ⏎ symbol for keybinding hint consistency                                              
- Footer now reads: apply / pop / drop hints with uniform symbols                                                  
</details>                                                                                                         
                                                                                                                   
<details>                                                                                                          
<summary>style(tv): switch theme to catppuccin (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/        
48b86df7">48b86df7</a>)</summary>                                                                                  
                                                                                                                   
- Change default television theme from "default" to "catppuccin"                                                   
</details>                                                                                                         


## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #2018

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
