### PR TITLE
feat: Update AI agent providers

### DIFF
--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -17,6 +17,14 @@ apiKey  = "$OPENCODE_API_KEY"
   maxTokens     = 32000
 
   [[ai.providers.opencode.models]]
+  id            = "hy3-free"
+  name          = "Hy3"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 190000
+  maxTokens     = 64000
+
+  [[ai.providers.opencode.models]]
   id            = "nemotron-3-ultra-free"
   name          = "NVIDIA Nemotron 3 Ultra"
   reasoning     = true

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -59,6 +59,30 @@ baseUrl = "https:/openrouter.ai/api/v1"
 apiKey  = "$OPENROUTER_API_KEY"
 
   [[ai.providers.openrouter.models]]
+  id            = "minimax/minimax-m2.7:free"
+  name          = "MiniMax M2.7"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 196608
+  maxTokens     = 176947
+
+  [[ai.providers.openrouter.models]]
+  id            = "minimax/minimax-m3:free"
+  name          = "MiniMax M3"
+  reasoning     = true
+  input         = ["text", "image"]
+  contextWindow = 1048576
+  maxTokens     = 943718
+
+  [[ai.providers.openrouter.models]]
+  id            = "z-ai/glm-5.2:free"
+  name          = "GLM 5.2"
+  reasoning     = true
+  input         = ["text"]
+  contextWindow = 256000
+  maxTokens     = 230400
+
+  [[ai.providers.openrouter.models]]
   id            = "nvidia/nemotron-3.5-lightning:free"
   name          = "NVIDIA Nemotron 3.5 Super"
   reasoning     = true

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -9,14 +9,6 @@ baseUrl = "https:/opencode.ai/zen/v1"
 apiKey  = "$OPENCODE_API_KEY"
 
   [[ai.providers.opencode.models]]
-  id            = "x-preview-f-free"
-  name          = "Ox Alpha Free"
-  reasoning     = true
-  input         = ["text", "image"]
-  contextWindow = 1000000
-  maxTokens     = 131072
-
-  [[ai.providers.opencode.models]]
   id            = "mimo-v2.5-free"
   name          = "Mimo v2.5"
   reasoning     = true
@@ -57,14 +49,6 @@ api     = "openai-completions"
 npm     = "@ai-sdk/openai-compatible"
 baseUrl = "https:/openrouter.ai/api/v1"
 apiKey  = "$OPENROUTER_API_KEY"
-
-  [[ai.providers.openrouter.models]]
-  id            = "stealth/ox-alpha"
-  name          = "Ox Alpha"
-  reasoning     = true
-  input         = ["text", "image"]
-  contextWindow = 1048576
-  maxTokens     = 131072
 
   [[ai.providers.openrouter.models]]
   id            = "nvidia/nemotron-3.5-lightning:free"

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -125,29 +125,22 @@ baseUrl = "https:/ollama.com/v1"
 apiKey  = "$OLLAMA_API_KEY"
 
   [[ai.providers.ollama.models]]
-  id            = "glm-5.2:cloud"
-  name          = "GLM 5.2"
+  id            = "gpt-oss:120b-cloud"
+  name          = "gpt-oss-120b"
   reasoning     = true
-  contextWindow = 1000000
-  maxTokens     = 131072
+  contextWindow = 131072
+  maxTokens     = 32768
 
   [[ai.providers.ollama.models]]
-  id            = "kimi-k2.7-code:cloud"
-  name          = "Kimi K2.7 Code"
+  id            = "gemma4:31b-cloud"
+  name          = "Gemma 4 31B"
   reasoning     = true
   contextWindow = 262144
-  maxTokens     = 65536
+  maxTokens     = 16384
 
   [[ai.providers.ollama.models]]
-  id            = "glm-5.1:cloud"
-  name          = "GLM 5.1"
-  reasoning     = true
-  contextWindow = 202752
-  maxTokens     = 131072
-
-  [[ai.providers.ollama.models]]
-  id            = "kimi-k2.6:cloud"
-  name          = "Kimi k2.6"
+  id            = "nemotron-3-ultra:cloud"
+  name          = "NVIDIA Nemotron 3 Ultra "
   reasoning     = true
   contextWindow = 262144
   maxTokens     = 32768

--- a/home/.chezmoidata/ai/providers.toml
+++ b/home/.chezmoidata/ai/providers.toml
@@ -167,51 +167,19 @@ apiKey  = "$OLLAMA_API_KEY"
 # HuggingFace
 ################################################################################
 [ai.providers.huggingface]
-name    = "Ollama Cloud"
+name    = "HuggingFace"
 api     = "openai-completions"
 npm     = "@ai-sdk/openai-compatible"
 baseUrl = "https:/router.huggingface.co/v1"
 apiKey  = "$HUGGINGFACE_TOKEN"
 
   [[ai.providers.huggingface.models]]
-  id            = "deepseek-ai/deepseek-v4-pro"
-  name          = "DeepSeek-V4-Pro"
+  id            = "zai-org/GLM-4.7-Flash"
+  name          = "GLM-4.7-Flash"
   reasoning     = true
   input         = ["text"]
-  contextWindow = 1048576
-  maxTokens     = 393216
-
-  [[ai.providers.huggingface.models]]
-  id            = "moonshotai/kimi-k2.6"
-  name          = "Kimi k2.6"
-  reasoning     = true
-  input         = ["text", "image"]
-  contextWindow = 262144
-  maxTokens     = 262144
-
-  [[ai.providers.huggingface.models]]
-  id            = "minimaxai/minimax-m2.7"
-  name          = "MiniMax m2.7"
-  reasoning     = true
-  input         = ["text"]
-  contextWindow = 204800
-  maxTokens     = 131072
-
-  [[ai.providers.huggingface.models]]
-  id            = "zai-org/glm-5.1"
-  name          = "GLM-5.1"
-  reasoning     = true
-  input         = ["text"]
-  contextWindow = 202752
-  maxTokens     = 131072
-
-  [[ai.providers.huggingface.models]]
-  id            = "zai-org/glm-5"
-  name          = "GLM-5"
-  reasoning     = true
-  input         = ["text"]
-  contextWindow = 202752
-  maxTokens     = 131072
+  contextWindow = 200000
+  maxTokens     = 128000
 
 ################################################################################
 # Cerebras


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Add MiniMax M2.7, MiniMax M3, and GLM 5.2 free models to OpenRouter
- Rename Ollama Cloud provider to HuggingFace with updated model catalog
- Update Ollama cloud models to gpt-oss-120b, Gemma 4 31B, and Nemotron 3 Ultra
- Add Hy3 free model to opencode provider
- Remove deprecated preview AI models (Ox Alpha Free, Ox Alpha)

#### 🚨 Breaking Changes

<details>
<summary>None</summary>
</details>

#### 🎉 New Features

<details>
<summary>feat(ai): add MiniMax M2.7, MiniMax M3, and GLM 5.2 models to OpenRouter (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/05cb39d83e80c22c5e9f5919ab2904d8cf8289f2">05cb39d</a>)</summary>

- Add MiniMax M2.7 (free) with reasoning capability, text input, 196K context window
- Add MiniMax M3 (free) with reasoning capability, text and image input, 1M context window
- Add GLM 5.2 (free) with reasoning capability, text input, 256K context window
- All models configured under OpenRouter provider with free tier access
</details>

#### 🐞 Bug Fixes

<details>
<summary>None</summary>
</details>

#### Other Changes

<details>
<summary>refactor(ai): rename Ollama Cloud provider to HuggingFace and update models (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/723b764207e4c05524f05b5a7e35e7b93e5bedf3">723b764</a>)</summary>

- Rename provider from "Ollama Cloud" to "HuggingFace" with new base URL and API key
- Remove 5 deprecated models: DeepSeek-V4-Pro, Kimi k2.6, MiniMax m2.7, GLM-5.1, GLM-5
- Add GLM-4.7-Flash model with reasoning capability (200K context, 128K max tokens)
- Update provider to use HuggingFace router endpoint
</details>

<details>
<summary>refactor(ai): update Ollama cloud models to gpt-oss-120b, Gemma 4 31B, Nemotron 3 Ultra (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/c0a0ce973c0a9f04967f0175f9189329823f60da">c0a0ce9</a>)</summary>

- Replace GLM 5.2 with gpt-oss-120b (131K context, 32K max tokens)
- Replace Kimi K2.7 Code with Gemma 4 31B (262K context, 16K max tokens)
- Remove GLM 5.1 and Kimi k2.6 models
- Add NVIDIA Nemotron 3 Ultra (262K context, 32K max tokens)
</details>

<details>
<summary>chore(ai): add Hy3 free model to opencode provider (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/228641edc78efce2e735df34de88f82b484ae882">228641e</a>)</summary>

- Register "Hy3" (hy3-free) with reasoning capability
- Set context window to 190000 and max tokens to 64000
- Restrict input modality to text only
</details>

<details>
<summary>chore(ai): remove deprecated preview AI models (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/3000d74961e1a27720929b7c0f25827abbe4ee80">3000d74</a>)</summary>

- Drop "Ox Alpha Free" (x-preview-f-free) from opencode provider
- Drop "Ox Alpha" (stealth/ox-alpha) from openrouter provider
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #2020

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
