### PR TITLE
feat(cli): update mise tools

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -113,6 +113,7 @@ ruby    = "3"
 "aqua:simonwhitaker/gibo"       = "latest" # .gitignore boilerplates
 "aqua:evilmartians/lefthook"    = "latest" # Fast and powerful Git hooks manager for any type of projects.
 "aqua:dandavison/delta"         = "latest" # A syntax-highlighting pager for git, diff, grep, rg --json, and blame output
+"aqua:modem-dev/hunk"           = "latest" # Review-first terminal diff viewer for agentic coders
 
 ### Jujutsu
 "aqua:jj-vcs/jj"        = "latest" # A Git-compatible VCS that is both simple and powerful

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -209,6 +209,7 @@ ruby    = "3"
 "aqua:vercel-labs/agent-browser"          = { version = "latest" }
 "aqua:anomalyco/opencode"                 = { version = "latest", minimum_release_age = "2d" }
 "aqua:google-antigravity/antigravity-cli" = { version = "latest" }
+"github:AlexsJones/llmfit"                = "latest"
 
 ### AI utility
 "aqua:rtk-ai/rtk"            = "latest" # High-performance CLI proxy that reduces LLM token consumption by 60-90%

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -143,7 +143,6 @@ ruby    = "3"
 "github:latex-lsp/texlab"              = "latest" # LaTex
 "github:docker/docker-language-server" = "latest" # Dockerfile, compose.yml
 "github:sqls-server/sqls"              = "latest" # SQL
-"aqua:Automattic/harper/harper-ls"     = "latest" # Offline, privacy-first grammar checker. Fast, open-source, Rust-powered
 
 ## Debugger
 "github:vadimcn/vscode-lldb"           = "latest" # C/C++, Rust, Zig, Swift


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Remove harper-ls grammar checker from mise toolchain
- Add hunk diff viewer via aqua backend
- Add llmfit CLI tool for LLM-related tasks

#### Other Changes

<details>
<summary>chore(mise): remove harper-ls grammar checker (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/094e0146ef220f7bfbfe6349f7ea2eb60404d4c1">094e014</a>)</summary>

- Remove Automattic/harper-ls from aqua backend tools
- Offline privacy-first grammar checker no longer needed in toolchain
</details>

<details>
<summary>chore(mise): add hunk diff viewer via aqua (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/d7300059e22421d9b516da61dff1bee847c17651">d730005</a>)</summary>

- Add modem-dev/hunk as a review-first terminal diff viewer for agentic coders
- Install via aqua backend for consistent version management
</details>

<details>
<summary>chore(mise): add llmfit tool from GitHub (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/86b4b9da589a114ab4ce3edb30c2eb9e40f347f0">86b4b9d</a>)</summary>

- Tool installed under AI utility section alongside rtk
- Enables llmfit CLI for LLM-related tasks
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #2027

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
