### PR TITLE
feat: Update LaTex config for Zed

### DIFF
--- a/home/.chezmoidata/packages.toml
+++ b/home/.chezmoidata/packages.toml
@@ -35,7 +35,7 @@
   archive     = ["suspicious-package"]
   launcher    = ["raycast"]
   browser     = ["google-chrome", "brave-browser", "firefox"]
-  previewer   = []
+  previewer   = ["skim"]
   terminal    = ["wezterm", "ghostty"]
   agent       = ["antigravity"]
   ide         = ["zed"]

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -428,12 +428,14 @@
     },
     "Markdown-Inline": {
       "show_edit_predictions": false
-    {{/*
+    },
+    "BibTex": {
+      "format_on_save": "on",
+      "formatter": { "language_server": { "name": "texlab" } }
     },
     "LaTex": {
       "format_on_save": "on",
-      "formatter": { "external": { "command": "yamlfmt", "arguments": [ "--filename", "{buffer_path}" ] } },
-    */ -}}
+      "formatter": { "language_server": { "name": "texlab" } }
     }
   },
   {{/*

--- a/home/.chezmoitemplates/common/zed/settings.json.tmpl
+++ b/home/.chezmoitemplates/common/zed/settings.json.tmpl
@@ -292,7 +292,18 @@
     "texlab": {
       "settings": {
         "texlab": {
-          "build": { "onSave": false, "forwardSearchAfter": true },
+          "build": {
+            "onSave": false,
+            "pdfDirectory": "out",
+            "auxDirectory": "build",
+            "forwardSearchAfter": true,
+            "executable": "latexmk",
+            "args": ["-pdf", "-synctex=1", "-outdir=out", "auxdir=build"]
+          },
+          "forwardSearch": {
+            "executable": "~/Skim.app/Contents/SharedSupport/displayline",
+            "args": ["-g", "-r", "%l", "%p", "%f"]
+          },
           "formatterLineLength": 120,
           "bibtexFormatter": "texlab",
           "latexFormatter": "texlab",


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

### Changelog

#### What's Changed

- Added BibTex and LaTex language settings for Zed editor
- Added texlab settings for LaTeX support in Zed
- Added skim to previewer packages

#### 🎉 New Features

<details>
<summary>feat(zed): add BibTex and LaTex language settings (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/1d7901db">1d7901db</a>)</summary>

- Add BibTex language settings with texlab formatter
- Update LaTex language settings to use texlab formatter
- Remove template comment for these settings
</details>

<details>
<summary>feat(zed): add texlab settings for latex support (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/84b8c698">84b8c698</a>)</summary>

- Add build configuration for texlab with custom directories and executable
- Add forward search settings using Skim.app for PDF previewing
- Update formatter line length and bibtex/latex formatters
</details>

#### Other Changes

<details>
<summary>chore(packages): add skim to previewer packages (<a href="https://github.com/MasahiroSakoda/dotfiles/commit/95388552">95388552</a>)</summary>

- Add skim to previewer list in packages.toml
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #2038

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
